### PR TITLE
fix(values): accept zero-padded XML character references

### DIFF
--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -363,9 +363,9 @@
     },
     {
       "path": "dist/src/values/unicode-scalar.d.ts",
-      "bytes": 1159,
-      "sha256": "f616e88ead76f893828b480631f069a95b46c5406bc2d677eb140dedf896d4ec"
+      "bytes": 1191,
+      "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "2d6215e9e78901c09c131f7ca40c00d199918e8a075e30d7aad0d8323548370a"
+  "aggregateSha256": "44b4c2af00ffa3f4e94dc2f47bbdddc9993c3020c49f7ff9757e8606f441390e"
 }

--- a/docs/plans/completed/xml-character-reference-widths.md
+++ b/docs/plans/completed/xml-character-reference-widths.md
@@ -1,0 +1,122 @@
+# Plan: accept zero-padded XML character references
+
+Research: [`docs/research/xml-character-reference-widths.md`](../../research/xml-character-reference-widths.md)
+
+## Goal
+
+`decodeXmlEntityReference` accepts any conforming character reference regardless
+of how it is padded, and still refuses a digit run long enough to be a cost.
+
+## Approach
+
+Separate the two jobs the current pattern conflates.
+
+1. **Bound the raw run** — a generous cap that exists only to stop an unbounded
+   slice and parse. It should be far above any legitimate spelling, so it never
+   decides whether conforming input is accepted.
+2. **Decide legality by value** — strip leading zeros, parse, and let the
+   existing scalar-range check reject anything out of range. That check already
+   rejects surrogates and anything above `U+10FFFF`, so it is the right place
+   for the decision and needs no change.
+
+The raw cap is set at 32 characters for both forms. The largest conforming
+reference anyone writes deliberately is `&#x10FFFF;` at six hex digits or
+`&#1114111;` at seven decimal digits; 32 leaves room for any plausible padding
+while keeping the parsed run trivially small.
+
+Stripping leading zeros from a run of all zeros must leave `"0"`, not the empty
+string, so `&#0;` and `&#x0;` keep decoding to U+0000 — the readers admit C0
+controls in reference position because our own writer emits `&#00;`.
+
+## Changes
+
+Only `src/values/unicode-scalar.ts`. Both call sites in the xRFC readers are
+unchanged: they already apply their own code-point policy on top and are
+unaffected by how the reference was spelled.
+
+## Tests
+
+Added to the existing xRFC entity coverage.
+
+- **Padding is transparent.** For a representative set of code points, every
+  zero-padded spelling from the minimum width up to the raw cap decodes to the
+  same scalar as the unpadded spelling. This is the property that was broken.
+- **`&#0;` and `&#x0;` still decode to U+0000**, and so do their padded forms.
+- **The maximum scalar padded**: `&#x00010FFFF;` decodes to U+10FFFF.
+- **Fail-closed regressions, which must not loosen:**
+  - a run above the raw cap is refused
+  - an out-of-range value is refused however it is padded — `&#x0000110000;`
+  - a surrogate is refused however it is padded — `&#x00D800;`
+  - an empty reference, an unterminated reference, and an unknown named entity
+    are all still refused
+- **Control the tests.** Revert the change and confirm the padding tests fail
+  and the fail-closed tests still pass. A fail-closed test that passes in both
+  states is guarding the bound rather than the fix, which is correct; a padding
+  test that passes in both states would mean it never tested anything.
+
+## Verification
+
+- `npm run test:public`, `npm run lint`, `npm run check:docs:public`
+- Round-trip unchanged: what our writers emit still parses to the same values.
+
+## Release
+
+A `fix:` commit. Under this repository's release-please configuration
+(`bump-patch-for-minor-pre-major`), that is a patch bump: **0.2.0 → 0.2.1**.
+
+## Out of scope
+
+The writers, the code-point policies in either reader, and the structural
+grammar limits recorded as open questions elsewhere. This plan changes how a
+reference is *spelled*, not which characters are admitted.
+
+---
+
+## Outcome
+
+Implemented in `src/values/unicode-scalar.ts`. The width-bounded patterns became
+a shared `characterReferenceValue` helper: it bounds the raw run at 32
+characters, strips leading zeros, and parses the significant digits. The existing
+scalar-range check was already in the right place and is unchanged.
+
+`test/xml-entity-reference.test.ts` — eight tests, discovered automatically by
+the public suite because compiled tests are enumerated from `dist/test`.
+
+### The control test found something the plan predicted wrong
+
+The plan expected the fail-closed tests to pass in both states. Three did. Two
+did not, and the reason is worth recording.
+
+Reverting the fix left this:
+
+| Test | Unfixed | Fixed |
+|---|---|---|
+| padded widths decode identically | fail | pass |
+| all-zero reference is U+0000 | fail | pass |
+| consumed length covers the reference | fail | pass |
+| named entities decode | pass | pass |
+| run past the raw bound is refused | pass | pass |
+| out-of-range refused however padded | **fail** | pass |
+| surrogate refused however padded | **fail** | pass |
+| malformed references refused | pass | pass |
+
+The two surprises are the padded out-of-range and padded surrogate cases. The
+old decoder *did* refuse them — but for the wrong reason. `&#x0000D800;` was
+refused as `unsupported XML entity`, because it had too many digits, not as
+`out-of-range XML entity`, because it denotes a surrogate. The tests assert the
+message, so they caught the difference.
+
+That is a better result than the plan anticipated. A refusal that happens
+incidentally is one you cannot rely on: had anyone later raised the digit bound
+for an unrelated reason, the old decoder would have started accepting surrogates
+silently. The fix makes the value the thing that decides, so the refusal now
+comes from the check that means it.
+
+### Verification
+
+- `npm run test:public` — passed, 3 compiled and 11 source test files
+- `npm run lint` — clean
+- `npm run check:docs:public` — 24 files, 39 links, 7 executable examples
+- `conformance/api/public-types.v1.json` regenerated: `unicode-scalar.d.ts` grew
+  by 32 bytes from the revised comment. Exported names are byte-identical, so
+  the public API did not move.

--- a/docs/research/xml-character-reference-widths.md
+++ b/docs/research/xml-character-reference-widths.md
@@ -1,0 +1,77 @@
+# Research: XML character reference widths in xRFC text
+
+## Question
+
+`decodeXmlEntityReference` bounds a character reference by how many digits it
+contains. Does that bound refuse input the XML specification permits?
+
+## What the specification says
+
+XML 1.0, section 4.1:
+
+```
+CharRef ::= '&#' [0-9]+ ';'  |  '&#x' [0-9a-fA-F]+ ';'
+```
+
+Both productions use `+`, so a reference may carry **any number of digits**. The
+constraint the specification places on a character reference is on its *value* —
+it must denote a legal character — not on its width. `&#65;`, `&#065;` and
+`&#00000065;` are three spellings of the same character, and all three conform.
+
+## What the code does
+
+`src/values/unicode-scalar.ts` validates the digit run with a width-bounded
+pattern: `/^[0-9]{1,7}$/u` for decimal and `/^[0-9A-Fa-f]{1,6}$/u` for
+hexadecimal. Those widths were chosen so the parsed value cannot exceed the
+Unicode range by much, and so a long run cannot become a decode cost. Both are
+sound intentions.
+
+But a digit *count* is not a value bound. Zero padding adds digits without
+changing the value, so a conforming reference is refused for its spelling.
+
+## Measurement
+
+Probing the built decoder directly:
+
+| Reference | Result | Note |
+|---|---|---|
+| `&#65;` | U+0041 | |
+| `&#065;` | U+0041 | one leading zero is accepted |
+| `&#0000065;` | U+0041 | seven digits is the limit |
+| `&#00000065;` | **refused** | eight digits — conforming XML |
+| `&#x41;` | U+0041 | |
+| `&#x0041;` | U+0041 | |
+| `&#x000041;` | U+0041 | six digits is the limit |
+| `&#x0000041;` | **refused** | seven digits — conforming XML |
+| `&#x10FFFF;` | U+10FFFF | |
+| `&#x00010FFFF;` | **refused** | the maximum scalar, zero-padded |
+
+The refusal message is `contains an unsupported XML entity`, which describes a
+reference this reader does not implement. A zero-padded reference is not
+unsupported; it is ordinary.
+
+## Why it matters
+
+This is the same shape as the defect that motivated widening these readers in
+the first place: our writer emits one narrow spelling, the reader was built to
+accept what our writer emits, and a conforming peer that spells it differently
+is refused. Fixed-width zero padding is a common habit in generated XML, so
+this is reachable rather than theoretical.
+
+The blast radius is a refused decode of an otherwise valid payload — the reader
+fails closed, so there is no risk of misreading a value. The cost is a
+connection that works against one producer and not another.
+
+## Constraint the fix must preserve
+
+The digit bound is doing real work: without any bound, a reference containing a
+very long digit run turns into an unbounded `parseInt` and an unbounded slice.
+The fix must keep a bound on the raw run while making the *value* the thing that
+decides legality, so zero padding is free but a genuinely huge run is still
+refused.
+
+## Not changed
+
+The writers. They emit a deliberately narrow canonical subset — C0 controls plus
+`&`, `<` and `>` as two-digit decimal references — and that subset is conforming.
+A reader accepting more than its writer emits is the correct asymmetry.

--- a/src/values/unicode-scalar.ts
+++ b/src/values/unicode-scalar.ts
@@ -37,6 +37,34 @@ const NAMED_XML_ENTITY_CODE_POINTS = new Map([
 ]);
 
 /**
+ * A character reference may carry any number of digits: XML 1.0 spells both
+ * forms with `+`, so zero padding is a spelling choice and not a different
+ * reference. These patterns therefore bound the raw run only, far above any
+ * deliberate spelling, so that a very long run cannot become a parse cost. What
+ * the reference actually denotes is decided by its value, below.
+ */
+const MAXIMUM_CHARACTER_REFERENCE_RUN = 32;
+const DECIMAL_RUN = /^[0-9]+$/u;
+const HEXADECIMAL_RUN = /^[0-9A-Fa-f]+$/u;
+
+/** Value of one character reference digit run, ignoring how it is padded. */
+function characterReferenceValue(
+  digits: string,
+  radix: number,
+  run: RegExp,
+  path: string,
+): number {
+  if (digits.length > MAXIMUM_CHARACTER_REFERENCE_RUN || !run.test(digits)) {
+    throw new Error(`${path} contains an unsupported XML entity`);
+  }
+  // An all-zero run denotes U+0000 rather than nothing, so keep one digit. Our
+  // own writers emit `&#00;`, and the readers admit C0 controls in reference
+  // position, so this path is exercised by ordinary round-trips.
+  const significant = digits.replace(/^0+/u, "") || "0";
+  return Number.parseInt(significant, radix);
+}
+
+/**
  * Decode the XML reference starting at `raw[start]`, which must be `&`, and
  * report the code point together with the consumed reference length.
  *
@@ -45,8 +73,9 @@ const NAMED_XML_ENTITY_CODE_POINTS = new Map([
  * character references of any legal width. Our writers emit a narrow canonical
  * subset of that grammar, but a producer following the specification may send
  * any of it, so the readers accept all of it. Digit runs are bounded so a long
- * reference cannot become a decode cost, and the result is guaranteed to be a
- * Unicode scalar. Callers apply their own code-point policy on top.
+ * reference cannot become a decode cost, zero padding is transparent, and the
+ * result is guaranteed to be a Unicode scalar. Callers apply their own
+ * code-point policy on top.
  */
 export function decodeXmlEntityReference(
   raw: string,
@@ -66,17 +95,9 @@ export function decodeXmlEntityReference(
     }
     codePoint = named;
   } else if (body[1] === "x") {
-    const digits = body.slice(2);
-    if (!/^[0-9A-Fa-f]{1,6}$/u.test(digits)) {
-      throw new Error(`${path} contains an unsupported XML entity`);
-    }
-    codePoint = Number.parseInt(digits, 16);
+    codePoint = characterReferenceValue(body.slice(2), 16, HEXADECIMAL_RUN, path);
   } else {
-    const digits = body.slice(1);
-    if (!/^[0-9]{1,7}$/u.test(digits)) {
-      throw new Error(`${path} contains an unsupported XML entity`);
-    }
-    codePoint = Number.parseInt(digits, 10);
+    codePoint = characterReferenceValue(body.slice(1), 10, DECIMAL_RUN, path);
   }
   if (codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
     throw new Error(`${path} contains an out-of-range XML entity`);

--- a/test/xml-entity-reference.test.ts
+++ b/test/xml-entity-reference.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { decodeXmlEntityReference } from "../src/values/unicode-scalar.js";
+
+const PATH = "VALUE.TEXT";
+
+function decode(reference: string): number {
+  return decodeXmlEntityReference(reference, 0, PATH).codePoint;
+}
+
+function padded(codePoint: number, radix: 10 | 16, width: number): string {
+  const digits = codePoint.toString(radix).toUpperCase().padStart(width, "0");
+  return radix === 16 ? `&#x${digits};` : `&#${digits};`;
+}
+
+// XML 1.0 spells both character-reference forms with `+`, so a reference may
+// carry any number of digits and zero padding is a spelling rather than a
+// different reference. This is the property the readers previously broke: they
+// bounded the digit COUNT, so a conforming producer that zero-pads was refused.
+test("a character reference decodes the same at every padded width", () => {
+  const scalars = [0x00, 0x09, 0x26, 0x41, 0x7f, 0xa0, 0x20ac, 0xffff, 0x10000, 0x10ffff];
+  for (const codePoint of scalars) {
+    for (const [radix, minimum] of [[10, 1], [16, 1]] as const) {
+      const shortest = codePoint.toString(radix).length;
+      assert.ok(shortest >= minimum);
+      for (let width = shortest; width <= 32; width += 1) {
+        const reference = padded(codePoint, radix, width);
+        assert.equal(
+          decode(reference),
+          codePoint,
+          `${reference} should decode to U+${codePoint.toString(16).toUpperCase()}`,
+        );
+      }
+    }
+  }
+});
+
+// An all-zero run denotes U+0000, not an empty reference. Our own writers emit
+// `&#00;` for C0 controls, so this is an ordinary round-trip and not an edge.
+test("an all-zero reference decodes to U+0000 at every width", () => {
+  for (let width = 1; width <= 32; width += 1) {
+    assert.equal(decode(`&#${"0".repeat(width)};`), 0x00);
+    assert.equal(decode(`&#x${"0".repeat(width)};`), 0x00);
+  }
+});
+
+test("the consumed length covers the whole reference however it is padded", () => {
+  const reference = "&#x00000041;";
+  const decoded = decodeXmlEntityReference(`${reference}rest`, 0, PATH);
+  assert.equal(decoded.codePoint, 0x41);
+  assert.equal(decoded.length, reference.length);
+});
+
+test("the five predefined named entities still decode", () => {
+  assert.equal(decode("&amp;"), 0x26);
+  assert.equal(decode("&lt;"), 0x3c);
+  assert.equal(decode("&gt;"), 0x3e);
+  assert.equal(decode("&quot;"), 0x22);
+  assert.equal(decode("&apos;"), 0x27);
+});
+
+// Everything below must fail closed. These pass before and after the widening,
+// which is correct: they guard the bound rather than the fix. A padding test
+// that passed in both states would mean it never tested anything.
+test("a digit run past the raw bound is refused", () => {
+  assert.throws(() => decode(`&#${"0".repeat(33)};`), /unsupported XML entity/u);
+  assert.throws(() => decode(`&#x${"0".repeat(33)};`), /unsupported XML entity/u);
+});
+
+test("an out-of-range value is refused however it is padded", () => {
+  for (const reference of ["&#x110000;", "&#x0000110000;", "&#1114112;", "&#0001114112;"]) {
+    assert.throws(() => decode(reference), /out-of-range XML entity/u, reference);
+  }
+});
+
+test("a surrogate is refused however it is padded", () => {
+  for (const reference of ["&#xD800;", "&#x0000D800;", "&#xDFFF;", "&#55296;", "&#0055296;"]) {
+    assert.throws(() => decode(reference), /out-of-range XML entity/u, reference);
+  }
+});
+
+test("malformed references are still refused", () => {
+  assert.throws(() => decode("&;"), /empty XML entity/u);
+  assert.throws(() => decode("&#;"), /unsupported XML entity/u);
+  assert.throws(() => decode("&#x;"), /unsupported XML entity/u);
+  assert.throws(() => decode("&amp"), /truncated XML entity/u);
+  assert.throws(() => decode("&nbsp;"), /unsupported XML entity/u);
+  assert.throws(() => decode("&#12z4;"), /unsupported XML entity/u);
+  // `&#X41;` is not the XML grammar: the specification spells the marker in
+  // lowercase, so this is a decimal run beginning with a letter.
+  assert.throws(() => decode("&#X41;"), /unsupported XML entity/u);
+});


### PR DESCRIPTION
## The bug

XML 1.0 spells both character-reference forms with `+`:

```
CharRef ::= '&#' [0-9]+ ';'  |  '&#x' [0-9a-fA-F]+ ';'
```

A reference may carry **any number of digits**. Zero padding is a spelling, not a
different reference. The reader bounded the digit *count* instead — seven decimal,
six hexadecimal — so conforming input was refused for how it was written:

| Reference | Before | After |
|---|---|---|
| `&#65;` | U+0041 | U+0041 |
| `&#00000065;` | **refused** | U+0041 |
| `&#x0000041;` | **refused** | U+0041 |
| `&#x00010FFFF;` | **refused** | U+10FFFF |

This is the same shape as the defect that motivated widening these readers in the
first place: our writer emits one narrow spelling, the reader was built around
what our writer emits, and a conforming peer that spells it differently cannot
connect. Fixed-width zero padding is common in generated XML, so this is
reachable rather than theoretical. It fails closed, so nothing was ever misread —
the cost is a connection that works against one producer and not another.

## The fix

The bound is still there and still needed; without one a long digit run becomes
an unbounded parse. It now bounds the **raw run** at 32 characters — far above
any deliberate spelling — and legality is decided by the **value**: strip leading
zeros, parse, and let the existing scalar-range check reject surrogates and
anything above `U+10FFFF`. An all-zero run keeps one digit, so `&#0;` stays
U+0000, which our own writers emit for C0 controls.

Writers are untouched. A reader accepting more than its writer emits is the
correct asymmetry.

## What the control test found

Reverting the fix to check the tests actually test something turned up one thing
the plan got wrong. Three of the five fail-closed tests passed in both states, as
expected. Two did not — and the reason matters.

The old decoder *did* refuse `&#x0000D800;`. But as an **unsupported entity**,
for having too many digits — not as **out of range**, for denoting a surrogate.
The refusal was incidental. Had anyone raised the digit bound later for an
unrelated reason, the decoder would have started admitting surrogates silently.
The value now decides, so the refusal comes from the check that means it.

## Verification

- `npm run test:public` — passed, 3 compiled and 11 source test files
- `npm run lint` — clean
- `npm run check:docs:public` — 24 files, 39 links, 7 executable examples
- API snapshot regenerated: `unicode-scalar.d.ts` grew 32 bytes from the revised
  comment. Exported names byte-identical, so the public API did not move.

## Documents

- [`docs/research/xml-character-reference-widths.md`](docs/research/xml-character-reference-widths.md) — the specification question and the measurement
- [`docs/plans/completed/xml-character-reference-widths.md`](docs/plans/completed/xml-character-reference-widths.md) — the plan and its outcome, including the control-test table

## Release

`fix:` — under `bump-patch-for-minor-pre-major`, a patch bump: **0.2.0 → 0.2.1**.
