### PR TITLE
docs: simplify quick start and add runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Save this as `rfc-smoke.mjs`, provide the four required environment variables,
 and run `node rfc-smoke.mjs`. It makes one read-only echo call and closes the
 client. The example reports only fixed success or failure text.
 
-<!-- open-rfc-doc-example id="readme-quick-start" runtime="esm" outcome="missing-connection" sha256="27f0daa2f1729ef1baa29944f89bdaa009da2750fa9926e527f302c5740d0079" -->
+<!-- open-rfc-doc-example id="readme-quick-start" runtime="esm" outcome="missing-connection" sha256="1264e4ed0f1e45915912f4ccd5f31a39caddbd92d4891ed73bf8138556539417" -->
 ```js
 import { Client } from "open-rfc";
 
@@ -67,9 +67,11 @@ if (missing.length > 0) {
     { timeout: 15 },
   );
 
+  let opened = false;
   let failed = false;
   try {
     await client.open();
+    opened = true;
     await client.call("STFC_CONNECTION", {
       REQUTEXT: "hello from open-rfc",
     });
@@ -77,7 +79,7 @@ if (missing.length > 0) {
     failed = true;
     console.error("RFC call failed; consult private, redacted diagnostics.");
   } finally {
-    if (client.alive) {
+    if (opened) {
       try {
         await client.close();
       } catch {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,106 @@ the documented npm 11 override. The preview matrix covers representative
 lifecycle and standard transaction paths; project testing does not yet include
 the dedicated recovery, isolation, and transaction-failure aggregates.
 
-## Install
+## Quick start
+
+Install the package:
+
+```sh
+npm install open-rfc
+```
+
+Save this as `rfc-smoke.mjs`, provide the four required environment variables,
+and run `node rfc-smoke.mjs`. It makes one read-only echo call and closes the
+client. The example reports only fixed success or failure text.
+
+<!-- open-rfc-doc-example id="readme-quick-start" runtime="esm" outcome="missing-connection" sha256="27f0daa2f1729ef1baa29944f89bdaa009da2750fa9926e527f302c5740d0079" -->
+```js
+import { Client } from "open-rfc";
+
+const required = ["SAP_ASHOST", "SAP_CLIENT", "SAP_USER", "SAP_PASSWD"];
+const missing = required.filter((name) => !process.env[name]);
+
+if (missing.length > 0) {
+  console.error(
+    `Missing required SAP connection environment variables: ${missing.join(", ")}`,
+  );
+  process.exitCode = 1;
+} else {
+  const client = new Client(
+    {
+      ashost: process.env.SAP_ASHOST,
+      sysnr: process.env.SAP_SYSNR ?? "00",
+      client: process.env.SAP_CLIENT,
+      user: process.env.SAP_USER,
+      passwd: process.env.SAP_PASSWD,
+      lang: process.env.SAP_LANG ?? "EN",
+    },
+    { timeout: 15 },
+  );
+
+  let failed = false;
+  try {
+    await client.open();
+    await client.call("STFC_CONNECTION", {
+      REQUTEXT: "hello from open-rfc",
+    });
+  } catch {
+    failed = true;
+    console.error("RFC call failed; consult private, redacted diagnostics.");
+  } finally {
+    if (client.alive) {
+      try {
+        await client.close();
+      } catch {
+        failed = true;
+        console.error("RFC close failed; consult private, redacted diagnostics.");
+      }
+    }
+  }
+
+  if (failed) process.exitCode = 1;
+  else console.log("hello from open-rfc");
+}
+```
+
+Use a read-only RFM on an approved non-production system for the first test.
+Connection fields use the connector's documented spelling, and RFC parameter
+names keep the exact metadata casing: `REQUTEXT`, not `requtext`. Keep
+credentials, parameters, returned tables, raw frames, and backend identity out
+of logs.
+
+> Direct classic RFC does not provide transport encryption or peer
+> authentication. Use it only on a trusted private network or inside a
+> separately managed protected tunnel; never send credentials or RFC traffic
+> across an untrusted network. SAProuter is unsupported and does not by itself
+> add transport encryption.
+
+## Full runnable examples
+
+The tagged source repository contains complete, production-shaped Promise
+examples for both Node.js module systems:
+
+- ESM: `examples/standalone/hello-world.mjs`
+- CommonJS: `examples/standalone/hello-world.cjs`
+
+They validate configuration, use a finite timeout, preserve call and cleanup
+failures together, avoid printing arbitrary SAP responses, and always attempt
+to close an opened client. From a matching source tag, build once and run either
+file:
+
+```sh
+npm ci --ignore-scripts --no-audit --no-fund
+npm run build
+node examples/standalone/hello-world.mjs
+node examples/standalone/hello-world.cjs
+```
+
+The npm tarball intentionally does not install a project-level `examples/`
+directory. The [documentation site](https://marianfoo.github.io/open-rfc/)
+includes copy-paste versions of the complete examples for the exact version it
+names.
+
+## Install and verify a release
 
 Ubuntu 24.04 x64 with Node.js `^22.14.0` or `^24.0.0` is required by the beta
 support contract. Reproduce release and lockfile verification with the npm
@@ -40,8 +139,8 @@ release, copy its exact version from the matching release record and save it
 without a range:
 
 The standalone package does not call npm at runtime. npm 11 is the reproducible
-installation and release-verification tool and the requirement for the CAP override, not
-an additional runtime dependency.
+installation and release-verification tool and the requirement for the CAP
+override, not an additional runtime dependency.
 
 ```sh
 OPEN_RFC_VERSION=x.y.z
@@ -96,95 +195,6 @@ addon, shared library, SDK archive, executable, credential, capture, or oracle
 material. These checks are a consumer sanity test; the published release record
 also identifies the source commit, npm CLI, complete file inventory, SBOM,
 declarations, and exact root artifact.
-
-## Quick start
-
-This complete ESM example calls the SAP-supplied `STFC_CONNECTION` echo RFM.
-Save the example as `rfc-smoke.mjs`, set the four required environment
-variables, and run `node rfc-smoke.mjs`. With no connection values it exits
-non-zero and names only the missing variable names; it never prints a value.
-On success it prints the fixed line `hello from open-rfc`.
-
-<!-- open-rfc-doc-example id="standalone-stfc-connection" runtime="esm" outcome="missing-connection" sha256="fa58f83cf581165e171c7078f2b313563c24b6587d86cc8681c598f2e2dd16e2" -->
-```js
-import { Client } from "open-rfc";
-
-const required = ["SAP_ASHOST", "SAP_CLIENT", "SAP_USER", "SAP_PASSWD"];
-const missing = required.filter((name) => !process.env[name]);
-
-if (missing.length > 0) {
-  console.error(
-    `Missing required SAP connection environment variables: ${missing.join(", ")}`,
-  );
-  process.exitCode = 1;
-} else {
-  const requestText = "hello from open-rfc";
-  const client = new Client(
-    {
-      ashost: process.env.SAP_ASHOST,
-      sysnr: process.env.SAP_SYSNR ?? "00",
-      client: process.env.SAP_CLIENT,
-      user: process.env.SAP_USER,
-      passwd: process.env.SAP_PASSWD,
-      lang: process.env.SAP_LANG ?? "EN",
-    },
-    { timeout: 15 },
-  );
-
-  let opened = false;
-  let failure;
-  try {
-    await client.open();
-    opened = true;
-    const result = await client.call("STFC_CONNECTION", {
-      REQUTEXT: requestText,
-    });
-    if (result.ECHOTEXT !== requestText) {
-      throw new Error("STFC_CONNECTION returned an unexpected echo");
-    }
-  } catch (error) {
-    failure = error;
-  }
-
-  if (opened) {
-    try {
-      await client.close();
-    } catch (closeError) {
-      failure = failure
-        ? new AggregateError(
-            [failure, closeError],
-            "RFC operation and close both failed",
-            { cause: failure },
-          )
-        : closeError;
-    }
-  }
-  if (failure) {
-    console.error("RFC operation failed; consult private, redacted diagnostics.");
-    process.exitCode = 1;
-  } else {
-    console.log("hello from open-rfc");
-  }
-}
-```
-
-If the call and `close()` both fail, the example preserves both errors and
-keeps the call failure as the primary cause internally. It emits only a fixed
-public failure line instead of letting Node.js print raw backend error text.
-Production code may send the retained error to an application-owned private
-handler only after applying its redaction policy.
-
-Use a read-only RFM on an approved non-production system for the first test.
-Connection property names shown above use the connector's documented spelling.
-RFC parameter names are matched to function metadata using their exact casing,
-normally uppercase: keep `REQUTEXT`, not `requtext`. Do not log credentials,
-parameters, returned tables, raw frames, or backend identity.
-
-> Direct classic RFC does not provide transport encryption or peer
-> authentication. Use it only on a trusted private network or inside a
-> separately managed protected tunnel; never send credentials or RFC traffic
-> across an untrusted network. SAProuter is unsupported and does not by itself add
-> transport encryption.
 
 ## What works—and what does not
 

--- a/docs_page/getting-started.md
+++ b/docs_page/getting-started.md
@@ -20,7 +20,16 @@ tag. The website can describe a newer release.
 - A remote-enabled ABAP function module and an RFC user authorized to call it.
 - Network access to the SAP gateway for the selected application server.
 
-## Install an exact release
+## Install
+
+For a first local evaluation, install the package with npm's ordinary package
+command:
+
+```sh
+npm install open-rfc
+```
+
+For a repeatable deployment, pin the exact version named by this page:
 
 ```sh
 npm install --save-exact open-rfc@{{OPEN_RFC_PACKAGE_VERSION}}

--- a/docs_page/standalone.md
+++ b/docs_page/standalone.md
@@ -1,6 +1,6 @@
 # A standalone RFC call
 
-<p class="open-rfc-lead">This complete example calls `STFC_CONNECTION`, prints one fixed success line, and always closes the session.</p>
+<p class="open-rfc-lead">These complete ESM and CommonJS examples call `STFC_CONNECTION`, print one fixed success line, and always close the session.</p>
 
 Save the first example as `rfc-smoke.mjs` and run it with
 `node rfc-smoke.mjs`. Missing connection configuration produces one sanitized,
@@ -75,6 +75,85 @@ If the call and `close()` both fail, the example preserves both errors and keeps
 the call failure as the primary cause internally. It emits only a fixed failure
 line; production code may route the retained object only to an
 application-owned private handler with an explicit redaction policy.
+
+## CommonJS
+
+Save this equivalent Promise example as `rfc-smoke.cjs` when the surrounding
+application uses CommonJS. The explicit `.cjs` extension makes the module
+format unambiguous without changing the application's `package.json`.
+
+<!-- open-rfc-doc-example id="pages-standalone-commonjs" runtime="cjs" outcome="missing-connection" sha256="d53a41e98048cbffcf6bb16a8be196f6c53a8f7c42ca0b42c48d89355b4517d7" -->
+```js
+"use strict";
+
+const { Client } = require("open-rfc");
+
+const required = ["SAP_ASHOST", "SAP_CLIENT", "SAP_USER", "SAP_PASSWD"];
+const missing = required.filter((name) => !process.env[name]);
+
+async function main() {
+  if (missing.length > 0) {
+    console.error(
+      `Missing required SAP connection environment variables: ${missing.join(", ")}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const requestText = "hello from open-rfc";
+  const client = new Client(
+    {
+      ashost: process.env.SAP_ASHOST,
+      sysnr: process.env.SAP_SYSNR ?? "00",
+      client: process.env.SAP_CLIENT,
+      user: process.env.SAP_USER,
+      passwd: process.env.SAP_PASSWD,
+      lang: process.env.SAP_LANG ?? "EN",
+    },
+    { timeout: 15 },
+  );
+
+  let opened = false;
+  let failure;
+  try {
+    await client.open();
+    opened = true;
+    const result = await client.call("STFC_CONNECTION", {
+      REQUTEXT: requestText,
+    });
+    if (result.ECHOTEXT !== requestText) {
+      throw new Error("STFC_CONNECTION returned an unexpected echo");
+    }
+  } catch (error) {
+    failure = error;
+  }
+
+  if (opened) {
+    try {
+      await client.close();
+    } catch (closeError) {
+      failure = failure
+        ? new AggregateError(
+            [failure, closeError],
+            "RFC operation and close both failed",
+            { cause: failure },
+          )
+        : closeError;
+    }
+  }
+  if (failure) {
+    console.error("RFC operation failed; consult private, redacted diagnostics.");
+    process.exitCode = 1;
+  } else {
+    console.log("hello from open-rfc");
+  }
+}
+
+void main().catch(() => {
+  console.error("RFC operation failed; consult private, redacted diagnostics.");
+  process.exitCode = 1;
+});
+```
 
 ## Operational rules
 

--- a/examples/standalone/README.md
+++ b/examples/standalone/README.md
@@ -1,12 +1,21 @@
-# Standalone example
+# Standalone examples
 
-This example uses the archived `node-rfc`-compatible `Client` surface from the
-SDK-free `open-rfc` package. It calls the SAP-supplied read/echo function
-`STFC_CONNECTION` and prints one fixed success line only after the call and
+These examples use the archived `node-rfc`-compatible `Client` surface from the
+SDK-free `open-rfc` package. They call the SAP-supplied read/echo function
+`STFC_CONNECTION` and print one fixed success line only after the call and
 cleanup both succeed.
 
-Install an exact reviewed `open-rfc` artifact in this directory's parent
-consumer, then provide connection values through the environment:
+From a matching source tag, install the repository dependencies and build the
+package once:
+
+```sh
+npm ci --ignore-scripts --no-audit --no-fund
+npm run build
+```
+
+If you copy either file into a separate application instead, install the exact
+reviewed `open-rfc` release in that application first. Then provide connection
+values through the environment:
 
 ```sh
 export SAP_ASHOST=app.example.invalid
@@ -17,6 +26,8 @@ read -rsp 'SAP password: ' SAP_PASSWD
 printf '\n'
 export SAP_PASSWD
 node examples/standalone/hello-world.mjs
+# Or, from the same shell, run the CommonJS version:
+node examples/standalone/hello-world.cjs
 unset SAP_PASSWD
 ```
 
@@ -28,7 +39,7 @@ response data.
 The password prompt above requires Bash. In unattended environments, inject
 `SAP_PASSWD` through the platform's secret manager instead. Do not put
 credentials in source, shell history, logs, traces, or bug reports.
-The example always closes the client. If the call and close both fail, it
+Each example always closes the client. If the call and close both fail, it
 preserves both errors and keeps the call failure as the primary cause
 internally, then emits only a fixed failure line. A timeout, cancellation,
 protocol error, or transport error is not automatically replayed. Production

--- a/examples/standalone/hello-world.cjs
+++ b/examples/standalone/hello-world.cjs
@@ -1,0 +1,69 @@
+"use strict";
+
+const { Client } = require("open-rfc");
+
+const required = ["SAP_ASHOST", "SAP_CLIENT", "SAP_USER", "SAP_PASSWD"];
+const missing = required.filter((name) => !process.env[name]);
+
+async function main() {
+  if (missing.length > 0) {
+    console.error(
+      `Missing required SAP connection environment variables: ${missing.join(", ")}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const requestText = "hello from open-rfc";
+  const client = new Client(
+    {
+      ashost: process.env.SAP_ASHOST,
+      sysnr: process.env.SAP_SYSNR ?? "00",
+      client: process.env.SAP_CLIENT,
+      user: process.env.SAP_USER,
+      passwd: process.env.SAP_PASSWD,
+      lang: process.env.SAP_LANG ?? "EN",
+    },
+    { timeout: 15 },
+  );
+
+  let opened = false;
+  let failure;
+  try {
+    await client.open();
+    opened = true;
+    const result = await client.call("STFC_CONNECTION", {
+      REQUTEXT: requestText,
+    });
+    if (result.ECHOTEXT !== requestText) {
+      throw new Error("STFC_CONNECTION returned an unexpected echo");
+    }
+  } catch (error) {
+    failure = error;
+  }
+
+  if (opened) {
+    try {
+      await client.close();
+    } catch (closeError) {
+      failure = failure
+        ? new AggregateError(
+            [failure, closeError],
+            "RFC operation and close both failed",
+            { cause: failure },
+          )
+        : closeError;
+    }
+  }
+  if (failure) {
+    console.error("RFC operation failed; consult private, redacted diagnostics.");
+    process.exitCode = 1;
+  } else {
+    console.log("hello from open-rfc");
+  }
+}
+
+void main().catch(() => {
+  console.error("RFC operation failed; consult private, redacted diagnostics.");
+  process.exitCode = 1;
+});

--- a/test/runnable-examples.test.mjs
+++ b/test/runnable-examples.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -25,11 +32,11 @@ function sanitizedEnvironment() {
   };
 }
 
-function runExample(relativePath) {
+function runExample(relativePath, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [relativePath], {
-      cwd: PROJECT_ROOT,
-      env: sanitizedEnvironment(),
+      cwd: options.cwd ?? PROJECT_ROOT,
+      env: options.env ?? sanitizedEnvironment(),
       stdio: ["ignore", "pipe", "pipe"],
     });
     const timeout = setTimeout(() => child.kill("SIGKILL"), 5_000);
@@ -84,6 +91,64 @@ test("the complete documentation examples match the runnable source files", () =
       "",
     );
     assert.equal(extracted.get(id), source);
+  }
+});
+
+test("the README closes an opened client after the call faults it", async () => {
+  const sourcePath = "README.md";
+  const documentation = readFileSync(join(PROJECT_ROOT, sourcePath), "utf8");
+  const example = extractDocumentationExamples(documentation, sourcePath).find(
+    ({ id }) => id === "readme-quick-start",
+  );
+  assert.ok(example);
+
+  const temporary = mkdtempSync(join(tmpdir(), "open-rfc-readme-cleanup-"));
+  const packageRoot = join(temporary, "node_modules", "open-rfc");
+  const marker = join(temporary, "closed.txt");
+  try {
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(
+      join(packageRoot, "package.json"),
+      JSON.stringify({ exports: "./index.mjs", type: "module" }),
+    );
+    writeFileSync(
+      join(packageRoot, "index.mjs"),
+      [
+        'import { writeFileSync } from "node:fs";',
+        "export class Client {",
+        "  alive = false;",
+        "  async open() { this.alive = true; }",
+        "  async call() { this.alive = false; throw new Error(\"synthetic fault\"); }",
+        "  async close() { writeFileSync(process.env.OPEN_RFC_CLOSE_MARKER, \"closed\\n\"); }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    const script = join(temporary, "rfc-smoke.mjs");
+    writeFileSync(script, `${example.source}\n`);
+
+    const result = await runExample(script, {
+      cwd: temporary,
+      env: {
+        ...sanitizedEnvironment(),
+        OPEN_RFC_CLOSE_MARKER: marker,
+        SAP_ASHOST: "example.invalid",
+        SAP_CLIENT: "001",
+        SAP_PASSWD: "synthetic",
+        SAP_USER: "synthetic",
+      },
+    });
+
+    assert.equal(result.signal, null);
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, "");
+    assert.equal(
+      result.stderr,
+      "RFC call failed; consult private, redacted diagnostics.\n",
+    );
+    assert.equal(readFileSync(marker, "utf8"), "closed\n");
+  } finally {
+    rmSync(temporary, { force: true, recursive: true });
   }
 });
 

--- a/test/runnable-examples.test.mjs
+++ b/test/runnable-examples.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { extractDocumentationExamples } from "../tools/documentation_examples.mjs";
+
+const PROJECT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const EXAMPLES = Object.freeze([
+  "examples/standalone/hello-world.mjs",
+  "examples/standalone/hello-world.cjs",
+]);
+const MISSING_CONFIGURATION =
+  "Missing required SAP connection environment variables: " +
+  "SAP_ASHOST, SAP_CLIENT, SAP_USER, SAP_PASSWD\n";
+
+function sanitizedEnvironment() {
+  return {
+    LANG: "C",
+    LC_ALL: "C",
+    NO_PROXY: "*",
+    no_proxy: "*",
+  };
+}
+
+function runExample(relativePath) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [relativePath], {
+      cwd: PROJECT_ROOT,
+      env: sanitizedEnvironment(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const timeout = setTimeout(() => child.kill("SIGKILL"), 5_000);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (value) => {
+      stdout += value;
+    });
+    child.stderr.on("data", (value) => {
+      stderr += value;
+    });
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (status, signal) => {
+      clearTimeout(timeout);
+      resolve({ signal, status, stderr, stdout });
+    });
+  });
+}
+
+test("the README leads with a simple install and discovers both runnable examples", () => {
+  const readme = readFileSync(join(PROJECT_ROOT, "README.md"), "utf8");
+  const quickInstall = readme.indexOf("npm install open-rfc");
+  const artifactVerification = readme.indexOf("## Verify an artifact");
+
+  assert.notEqual(quickInstall, -1);
+  assert.ok(quickInstall < artifactVerification);
+  for (const relativePath of EXAMPLES) assert.match(readme, new RegExp(relativePath));
+});
+
+test("the complete documentation examples match the runnable source files", () => {
+  const sourcePath = "docs_page/standalone.md";
+  const documentation = readFileSync(join(PROJECT_ROOT, sourcePath), "utf8");
+  const extracted = new Map(
+    extractDocumentationExamples(documentation, sourcePath).map((example) => [
+      example.id,
+      example.source,
+    ]),
+  );
+  const bindings = [
+    ["pages-standalone-stfc-connection", EXAMPLES[0]],
+    ["pages-standalone-commonjs", EXAMPLES[1]],
+  ];
+
+  for (const [id, relativePath] of bindings) {
+    const source = readFileSync(join(PROJECT_ROOT, relativePath), "utf8").replace(
+      /\n$/u,
+      "",
+    );
+    assert.equal(extracted.get(id), source);
+  }
+});
+
+for (const relativePath of EXAMPLES) {
+  test(`${relativePath} is complete and fails safely without configuration`, async () => {
+    const source = readFileSync(join(PROJECT_ROOT, relativePath), "utf8");
+    assert.match(source, /\bClient\b/u);
+    assert.match(source, /client\.open\(\)/u);
+    assert.match(source, /client\.call\("STFC_CONNECTION"/u);
+    assert.match(source, /client\.close\(\)/u);
+
+    const result = await runExample(relativePath);
+    assert.equal(result.signal, null);
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, MISSING_CONFIGURATION);
+  });
+}

--- a/tools/public_test_suite.mjs
+++ b/tools/public_test_suite.mjs
@@ -17,6 +17,7 @@ export const PUBLIC_MJS_TESTS = Object.freeze([
   "test/public-hosted-platform-evidence.test.mjs",
   "test/public-release-workflows.test.mjs",
   "test/public-support-links.test.mjs",
+  "test/runnable-examples.test.mjs",
   "test/tool-bounds.test.mjs",
   "test/trusted-git.test.mjs",
 ]);


### PR DESCRIPTION
## What changed

- move the ordinary `npm install open-rfc` path and a focused read-only call ahead of release-verification detail
- keep credential handling, finite timeouts, sanitized failures, and cleanup in the short example without the production error-aggregation machinery
- track successful `open()` completion so a later faulted client is still closed, with a behavioral regression for that lifecycle edge
- add complete Promise-based ESM and CommonJS programs under `examples/standalone/`
- publish the CommonJS program on the standalone documentation page
- execute both source examples with a scrubbed environment and bind the documentation snippets to those exact files

## Why

The original README made a first successful call compete with artifact-verification and production-lifecycle detail. Direct adopter feedback confirmed that the core path is much simpler: install, create a client, open, call, and close. This keeps that path visible while retaining the stricter deployment and cleanup guidance further down.

The successful adopter smoke test on Node 26 does not change the supported Node 22/24 contract; widening support needs the full qualification matrix.

## User impact

New users reach a working first-call shape immediately. Users who want a complete program can choose an unambiguous `.mjs` or `.cjs` example, and both variants are checked for safe behavior without configuration.

## Research inputs

- direct adopter feedback supplied privately by the maintainer; only the generic onboarding observation influenced this change
- npm's official install behavior and exact-save guidance
- Node.js's official package documentation for explicit `.mjs` and `.cjs` module formats

No private email content, system details, credentials, returned values, or live SAP evidence are included.

## Validation

- `npm run test:public` — 113 tests passed
- `npm run check:docs` — 8 ESM/CommonJS/TypeScript examples passed
- `npm run docs:site:check` — deterministic site render passed
- `npm run lint`
- `npm run package:shape -- --publication-mode public-license-preflight`
