### PR TITLE
feat: add BTP Connectivity SOCKS5 RFC route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `open-rfc` are recorded here. The project follows
 [Semantic Versioning](https://semver.org/) for the declared public surface once
 that surface is released.
 
+## Unreleased
+
+### Added
+
+- An unsupported direct named-user preview for classic RFC through the BTP
+  Connectivity SOCKS5 endpoint and an explicit Cloud Connector TCP mapping.
+
+### Fixed
+
+- The classic compatibility snapshot now retains Connectivity route parameters
+  so unsupported RFC-proxy requests fail closed instead of silently selecting a
+  direct connection.
+
 ## [0.2.2](https://github.com/marianfoo/open-rfc/compare/v0.2.1...v0.2.2) (2026-08-07)
 
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,10 @@ parameters, returned tables, raw frames, or backend identity.
   a Cloud Connector TCP mapping to the SAP gateway, and the explicit
   `connectivity_socks5_*` parameters documented on the site. It is not the
   separate Connectivity RFC proxy and cannot enforce Cloud Connector
-  function-module resources.
+  function-module resources. On Cloud Foundry, the Cloud Connector tunnel is a
+  subaccount-level trust boundary; its Trusted Applications allowlist is a
+  Neo-only control. Restrict Connectivity service-binding access and enforce
+  the function boundary with the SAP user's exact `S_RFC` role.
 - WebSocket RFC business calls, Cloud Connector principal propagation, SNC,
   and X.509 are not supported and fail closed before business I/O when their
   required provider or authentication capability is absent.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ parameters, returned tables, raw frames, or backend identity.
   are not supported by this release. Do not rely on those preview
   routes for its beta support contract; consult the status page shipped with a
   later exact version before assuming support changed.
+- BTP Connectivity SOCKS5/TCP routing for a direct named-user connection is an
+  implemented preview. It requires the Connectivity binding's SOCKS5 endpoint,
+  a Cloud Connector TCP mapping to the SAP gateway, and the explicit
+  `connectivity_socks5_*` parameters documented on the site. It is not the
+  separate Connectivity RFC proxy and cannot enforce Cloud Connector
+  function-module resources.
 - WebSocket RFC business calls, Cloud Connector principal propagation, SNC,
   and X.509 are not supported and fail closed before business I/O when their
   required provider or authentication capability is absent.
@@ -308,11 +314,11 @@ destination lookup, Cloud SDK behavior, or multitenancy. Direct
 application-server destinations using classic serialization and password
 authentication define the first-beta CAP route. Semantic transactions are
 supported only when a release's support record names live transaction testing
-for that exact artifact. Message-server and SAProuter are
-implemented previews but are not part of this release's beta support.
-WebSocket business calls, Cloud Connector principal propagation,
-SNC, and X.509 are unsupported and require capabilities the beta provider does
-not advertise.
+for that exact artifact. Message-server, SAProuter, and Connectivity SOCKS5/TCP
+are implemented previews but are not part of this release's beta support.
+WebSocket business calls, the Connectivity RFC proxy, Cloud Connector principal
+propagation, SNC, and X.509 are unsupported and require capabilities the beta
+provider does not advertise.
 
 ## Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,14 @@ and Cloud Connector principal propagation are not supported by the beta
 contract. Do not send credentials or classic RFC traffic across an untrusted
 network.
 
+The implemented BTP Connectivity SOCKS5/TCP preview is also outside the beta
+support contract. It uses a Cloud Connector TCP mapping, not the separate RFC
+proxy. TCP mappings are opaque to Cloud Connector and therefore cannot apply
+its RFC function-module resource allowlist. Restrict the mapping to trusted
+applications and enforce exact function access with a dedicated named user's
+least-privilege `S_RFC` role. Treat the Connectivity access token, location ID,
+service-binding client secret, and complete connection object as credentials.
+
 ## Supported versions
 
 Only an exact version published in both a matching GitHub Release and npm

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,11 @@ network.
 The implemented BTP Connectivity SOCKS5/TCP preview is also outside the beta
 support contract. It uses a Cloud Connector TCP mapping, not the separate RFC
 proxy. TCP mappings are opaque to Cloud Connector and therefore cannot apply
-its RFC function-module resource allowlist. Restrict the mapping to trusted
-applications and enforce exact function access with a dedicated named user's
+its RFC function-module resource allowlist. Cloud Connector's Trusted
+Applications allowlist applies to Neo, not Cloud Foundry. In CF, isolate
+production subaccounts and spaces, restrict who can create or consume
+Connectivity service bindings, expose only the exact virtual host and gateway
+port, and enforce exact function access with a dedicated named user's
 least-privilege `S_RFC` role. Treat the Connectivity access token, location ID,
 service-binding client secret, and complete connection object as credentials.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -22,6 +22,10 @@ These rows describe the support boundary of an exact published 0.x release.
   supported only when the public
   [release status](docs_page/status.md) includes them in the published artifact's
   documented boundary and names the checks performed.
+- The BTP Connectivity SOCKS5/TCP named-user route is an unsupported preview.
+  A successful Cloud Connector TCP call does not promote it into the beta
+  boundary and does not imply support for the separate RFC proxy or principal
+  propagation.
 
 The public [release status](docs_page/status.md) is the authoritative support
 boundary for a published version. Code that is not named there is not a

--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -3,7 +3,7 @@
   "module": "open-rfc",
   "packageContract": {
     "name": "open-rfc",
-    "version": "0.2.0",
+    "version": "0.2.2",
     "type": "module",
     "main": "./dist/cjs/index.js",
     "module": "./dist/src/index.js",
@@ -44,7 +44,7 @@
     "sha256": "3ced4556246b40fe4de22316ab1da7b6ae65ea0183a6a1d62e59fe08d293a041"
   },
   "subpathExportManifests": [],
-  "declarationCount": 64,
+  "declarationCount": 66,
   "declarations": [
     {
       "path": "dist/src/client/classic-invocation.d.ts",
@@ -78,8 +78,8 @@
     },
     {
       "path": "dist/src/compat/connection-route.d.ts",
-      "bytes": 3616,
-      "sha256": "c6e5e5caed86bf3359735181f3352343f65af44415943539141878b4a7aab865"
+      "bytes": 4115,
+      "sha256": "235381b430beac2de6658784406d64cd8c318b7f56f4d1e3611742cff8fae2a2"
     },
     {
       "path": "dist/src/compat/direct-owner-factory.d.ts",
@@ -88,8 +88,8 @@
     },
     {
       "path": "dist/src/compat/direct-rfc-session-provider.d.ts",
-      "bytes": 924,
-      "sha256": "d93cb12ca3e19ba096b98a14428f4d8f328ff02628777924b753c1ac4d0d4a34"
+      "bytes": 1188,
+      "sha256": "199a87e44d18d836ccd6838c67fdcc2239d3050e2d1198d3384348fd861832ed"
     },
     {
       "path": "dist/src/compat/message-server-direct-session-factory.d.ts",
@@ -282,6 +282,16 @@
       "sha256": "e823c19842bbbf788003e73945adf02ff0d7bff1b6d2c2de03bf62ec05569639"
     },
     {
+      "path": "dist/src/transport/connectivity-socks5-ni.d.ts",
+      "bytes": 1344,
+      "sha256": "8b91fcc0d84b0944a244deda3e38a9bd059dee50dbe1547b85bf4d9480faeda8"
+    },
+    {
+      "path": "dist/src/transport/connectivity-socks5-tunnel.d.ts",
+      "bytes": 4680,
+      "sha256": "14d687b02255c4c288df79a873ef5888e2147d61cd80a2034a37849e9863b427"
+    },
+    {
       "path": "dist/src/transport/message-server-resolver.d.ts",
       "bytes": 2406,
       "sha256": "516af9e02ea5f54a096875a5eee8f90f09c1778039b862073900a34ee94820f6"
@@ -367,5 +377,5 @@
       "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "44b4c2af00ffa3f4e94dc2f47bbdddc9993c3020c49f7ff9757e8606f441390e"
+  "aggregateSha256": "0421ceef6fe7023aee3aa3c754054b99902a95ecfde7e56d6739c5a4e2778cf7"
 }

--- a/docs/plans/connectivity-socks5-rfc-route.md
+++ b/docs/plans/connectivity-socks5-rfc-route.md
@@ -1,0 +1,147 @@
+# Plan: enable classic RFC through BTP Connectivity SOCKS5
+
+Research: [`docs/research/connectivity-socks5-rfc-route.md`](../research/connectivity-socks5-rfc-route.md)
+
+## Goal
+
+An ARC-1 extension deployed to BTP Cloud Foundry can make a named-user classic
+RFC call to an on-premise S/4HANA 2023 system through the bound Connectivity
+service and Cloud Connector.
+
+The change remains an unsupported preview. It does not claim RFC-proxy or
+principal-propagation support.
+
+## Reviewed design
+
+1. Add a separate `ConnectivitySocks5Plan` to route normalization. Require the
+   proxy host, SOCKS5 port, and raw access token together; allow an optional
+   location ID.
+2. Add a `connectivity-socks5-tcp` provider capability. Do not reuse or imply
+   the existing `connectivity-rfc-proxy` capability.
+3. Install the same-project bounded SOCKS5 tunnel beneath the direct CPIC
+   transport. Its target comes from normalized `gwhost`/`gwserv`, while its
+   proxy address and authentication material come from the new plan.
+4. Wire the route into the modern and classic direct providers. Reject it for
+   message-server, SAProuter, WebSocket, RFC-proxy, and propagated-identity
+   combinations before opening a socket.
+5. Add both new and existing Connectivity parameters to the classic immutable
+   connection snapshot. Existing RFC-proxy values must reach planning and fail
+   closed instead of disappearing into a direct route.
+6. Keep BTP binding selection and OAuth client-credentials token acquisition in
+   the ARC-1 extension. Open-rfc accepts a token but never owns, refreshes, or
+   logs the binding credentials.
+
+## Alternatives rejected during review
+
+### Point RFC-proxy parameters at the SOCKS5 port
+
+Rejected. SAP publishes different wire protocols and binding properties for
+the RFC and SOCKS5 endpoints. Port substitution is not protocol support.
+
+### Add OAuth and `VCAP_SERVICES` parsing to open-rfc
+
+Rejected. It would couple the transport core to Cloud Foundry service discovery,
+retain a long-lived client secret, complicate pool-generation ownership, and
+make the same route harder to use outside Cloud Foundry.
+
+### Preserve the classic client's ignored Connectivity parameters
+
+Rejected. Silent direct fallback violates the repository rule that a value
+which changes routing or identity may not disappear during normalization.
+
+### Advertise the route as supported
+
+Rejected. One system-level spike proves the intended topology but not the
+release matrix, long-running token rotation, fault variance, or operational
+soak required for a support claim.
+
+## Test plan
+
+### Protocol and resource tests
+
+- authenticate with SOCKS method `0x80` and the exact bounded token/location
+  frame;
+- encode IPv4 and domain-name `CONNECT` targets without local DNS resolution;
+- reject unsupported address types, malformed replies, oversized fields, and
+  invalid ports;
+- redact tokens from inspection and every diagnostic;
+- bound connect/authentication/handshake buffers and timeouts;
+- propagate abort and close every socket on failure or cancellation; and
+- adopt only a successfully connected, paused NI socket.
+
+### Route and compatibility contracts
+
+- accept the complete SOCKS5 tuple on a direct named-user route;
+- reject every partial tuple and a standalone location ID;
+- reject combinations with RFC proxy, principal propagation, message server,
+  SAProuter, and WebSocket;
+- prove the modern client advertises the capability only when a transport
+  factory is installed;
+- prove the classic client routes through that factory;
+- prove existing `connectivity_proxy_*` parameters now fail before network I/O
+  rather than falling back to direct; and
+- keep low-level tunnel modules out of the package root export.
+
+### Regression and package checks
+
+- run focused route, provider, compatibility, tunnel, and NI tests;
+- build and run the full public suite;
+- validate documentation and generated API snapshots;
+- lint the repository;
+- validate the exact public-license-preflight package shape; and
+- inspect the packed archive for credentials, private material, and accidental
+  new exports.
+
+### Live CF qualification
+
+- create a dedicated Cloud Connector TCP mapping to the 2023 gateway;
+- deploy a disposable ARC-1 extension build with a Connectivity service
+  binding;
+- retrieve the token inside the application and make `RFC_SYSTEM_INFO` through
+  the SOCKS5 route;
+- record only redacted success evidence; and
+- remove the disposable CF application after the check, retaining a mapping
+  only if it is intentionally part of the deployment configuration.
+
+## Test-plan review
+
+The protocol tests alone cannot prove Cloud Connector interoperability, while a
+green live call alone cannot prove malformed-input, cancellation, or redaction
+behavior. Both layers are therefore required. The live RFM is deliberately
+read-only and non-mutating. A successful `RFC_PING` is insufficient because it
+does not qualify metadata lookup or ordinary application authorization.
+
+The most important negative regression is the classic-client direct fallback:
+it must be observed to fail before any socket is opened. The most important
+secret regression is not only that errors omit the token, but that object
+inspection does as well.
+
+## Documentation and release
+
+Update the route, configuration, security, support, README, and changelog text.
+Use a signed `feat:` commit. The pull request must explicitly identify this as
+an unsupported preview and distinguish it from SAP Connectivity RFC proxy and
+principal propagation.
+
+## Out of scope
+
+- SAP Connectivity RFC-proxy wire support;
+- principal propagation, X.509, SNC, SSO, or token exchange with the ABAP
+  system;
+- message-server load balancing through the SOCKS5 route;
+- automatic OAuth token refresh inside open-rfc; and
+- a general-purpose SOCKS proxy API.
+
+## Outcome
+
+Implemented as designed. The protocol, route, classic-compatibility, modern
+client, documentation, API-snapshot, and package-shape checks pass. The live CF
+qualification completed the intended ARC-1 -> Connectivity SOCKS5 -> Cloud
+Connector TCP -> S/4HANA 2023 RFC path. It also corrected one planning detail:
+the extension must request a token from `<token_service_url>/oauth/token`, not
+from the binding's service base URL itself.
+
+The disposable qualification app was removed. The dedicated TCP mapping was
+retained intentionally for the target deployment, and the support status
+remains an unsupported preview pending broader interoperability and soak
+testing.

--- a/docs/research/connectivity-socks5-rfc-route.md
+++ b/docs/research/connectivity-socks5-rfc-route.md
@@ -1,0 +1,148 @@
+# Research: classic RFC through BTP Connectivity SOCKS5
+
+## Question
+
+Can an ARC-1 extension deployed to SAP BTP Cloud Foundry use `open-rfc` to
+call an on-premise S/4HANA 2023 application server through SAP Cloud
+Connector, without the SAP NW RFC SDK?
+
+## Conclusion
+
+Yes, for the password-authenticated direct application-server route, as an
+unsupported preview. The viable path is:
+
+```text
+ARC-1 extension
+  -> BTP Connectivity service SOCKS5 endpoint
+  -> Cloud Connector TCP system mapping
+  -> SAP gateway (33NN)
+  -> classic RFC session
+```
+
+This is not SAP's Connectivity RFC-proxy endpoint. The two endpoints use
+different ports and protocols. Treating `onpremise_proxy_rfc_port` as a
+SOCKS5 endpoint is incorrect, even when both values came from the same service
+binding.
+
+## Primary-source protocol contract
+
+SAP documents a dedicated SOCKS5 endpoint for arbitrary TCP applications:
+
+- the service binding supplies `onpremise_proxy_host` and
+  `onpremise_socks5_proxy_port`;
+- authentication method `0x80` is mandatory;
+- its authentication payload contains the raw Connectivity access token and,
+  optionally, a base64-encoded Cloud Connector location ID; and
+- a standard SOCKS5 `CONNECT` request follows successful authentication.
+
+The token is obtained from the Connectivity service's OAuth token endpoint by
+using the binding's client credentials. Current bindings provide the OAuth
+service base as `token_service_url`; the client-credentials request is sent to
+`<token_service_url>/oauth/token`. A live binding whose base path was `/`
+confirmed that using `token_service_url` itself returns the wrong endpoint.
+
+References:
+
+- [Using TCP Protocol for Cloud Applications](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/using-tcp-protocol-for-cloud-applications)
+- [Consuming the Connectivity Service](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/313b215066a8400db461b311e01bd99b.html)
+- [Configure Access Control (TCP)](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/configure-access-control-tcp)
+
+## Cloud Connector boundary
+
+Cloud Connector needs an explicit TCP system mapping whose virtual host and
+port are used in the SOCKS5 `CONNECT` request. For the direct RFC route the
+mapping's internal target is the application server's gateway service, normally
+`33NN`.
+
+`ashost` still names the SAP application server used by CPIC. `gwhost` and
+`gwserv` select the TCP endpoint. A Cloud Connector virtual host can therefore
+be supplied as `gwhost` without pretending that it is the SAP application
+server identity.
+
+TCP mappings are intentionally coarse. Cloud Connector cannot inspect the
+classic RFC payload and cannot enforce the function-level resource allowlist
+available to its RFC protocol mapping. The Cloud Foundry application and the
+named SAP principal are consequently part of the security boundary. The
+principal must have a minimal `S_RFC` role, and the application should be
+restricted through Cloud Connector's application allowlist where available.
+
+## Public-package gap
+
+`open-rfc@0.2.2` contains route planning for the separate Connectivity RFC
+proxy but deliberately rejects that capability. It does not contain the
+SOCKS5 transport described in the changelog, and its classic `Client` snapshot
+currently drops Connectivity parameters before planning. That creates two
+different failure modes:
+
+- the modern client fails closed for the unsupported RFC-proxy route; and
+- the classic client can silently fall back to a direct connection.
+
+The latter is hazardous because a caller can believe a private tunnel was
+selected when the route-changing values were discarded.
+
+## Same-project implementation lineage
+
+The project's private development history contains a bounded Connectivity
+SOCKS5 tunnel and an NI transport adapter, introduced in commit `a95c253` and
+subsequently hardened. The supporting public NI and direct-CPIC interfaces are
+byte-compatible with the current public repository. Reusing that same-project
+implementation preserves its limits, cancellation behavior, secret redaction,
+and wire-level tests while making the provenance explicit.
+
+No vendor binary, network capture, credential, customer data, or third-party
+source is copied.
+
+## API boundary
+
+The new route uses distinct parameters so it cannot be confused with the RFC
+proxy:
+
+| Parameter | Meaning |
+|---|---|
+| `connectivity_socks5_proxy_host` | `onpremise_proxy_host` from the Connectivity binding |
+| `connectivity_socks5_proxy_port` | `onpremise_socks5_proxy_port` from the binding |
+| `connectivity_socks5_access_token` | raw, short-lived Connectivity OAuth access token |
+| `connectivity_socks5_location_id` | optional Cloud Connector location ID |
+
+Host, port, and token are an all-or-nothing route selection. A location ID
+without that route is invalid. The token is caller-owned because open-rfc does
+not own BTP service discovery or OAuth client credentials. A client or pool
+must be recreated before the token expires.
+
+The route is limited to direct, named-user classic RFC. It must reject
+combinations with:
+
+- Connectivity RFC-proxy parameters;
+- principal propagation;
+- SAProuter;
+- message-server routing; and
+- WebSocket RFC.
+
+## Live qualification target
+
+The acceptance test is a deployed ARC-1 extension in Cloud Foundry that:
+
+1. reads exactly one Connectivity service binding;
+2. obtains and caches a Connectivity token only until shortly before expiry;
+3. passes the SOCKS5 route values to open-rfc without logging them;
+4. reaches an S/4HANA 2023 gateway through a Cloud Connector TCP mapping; and
+5. invokes one bounded, read-only RFC such as `RFC_SYSTEM_INFO` with a dedicated
+   named user.
+
+Principal propagation is a separate protocol and identity project. It is not a
+fallback or implicit next step for this route.
+
+## Live result
+
+Qualified on 2026-08-08 with the sample ARC-1 extension deployed as a
+disposable Cloud Foundry application and bound to the Connectivity service. A
+Cloud Foundry task loaded the extension and completed `RFC_SYSTEM_INFO` against
+the S/4HANA 2023 system through the Connectivity SOCKS5 endpoint and the Cloud
+Connector TCP mapping in 2.789 seconds. The task exited successfully and only
+the extension's allowlisted result fields were returned.
+
+The first qualification attempt also proved the OAuth endpoint distinction:
+posting to the service base failed, while appending `/oauth/token` returned a
+valid token. The disposable application was deleted after the test so its
+environment no longer retains the SAP or service-binding credentials. The TCP
+mapping was intentionally retained as deployment configuration.

--- a/docs_page/api.md
+++ b/docs_page/api.md
@@ -107,6 +107,19 @@ closed.
 | `cpic_streaming` | Optional `"disabled"` (default) or explicitly enabled `"enabled"`. |
 | `saprouter` | Implemented preview. The scoped first beta does not support this route even when the syntax validates and a connection succeeds. |
 
+### BTP Connectivity SOCKS5 (unsupported preview)
+
+| Field | Requirement and behavior |
+|---|---|
+| `connectivity_socks5_proxy_host` | Required with port and token; use the binding's `onpremise_proxy_host`. |
+| `connectivity_socks5_proxy_port` | Required with host and token; use `onpremise_socks5_proxy_port`, not the RFC-proxy port. |
+| `connectivity_socks5_access_token` | Required raw Connectivity access token without a `Bearer ` prefix. It is snapshotted and hidden from JSON/inspection. |
+| `connectivity_socks5_location_id` | Optional unencoded Cloud Connector location ID. |
+
+These fields select only a direct named-user route. The caller owns OAuth token
+acquisition and refresh. The low-level SOCKS5 transport is internal and is not
+exported from the package root.
+
 `cpic_streaming: "enabled"` is an advanced, target-specific opt-in, not a
 workaround for a rejected large request. The default `"disabled"` path is the
 public starting point. Use `"enabled"` only when the exact release record and

--- a/docs_page/configuration.md
+++ b/docs_page/configuration.md
@@ -53,17 +53,54 @@ additional fields:
 
 Set `gwhost` and `gwserv` to the TCP mapping's virtual host and port. Keep
 `ashost` as the actual SAP application-server identity carried by CPIC. Select
-exactly one Connectivity service binding, obtain its OAuth token with the
-binding client credentials at `<token_service_url>/oauth/token`, cache it only
-until shortly before expiry, and
-create a new client or pool for the replacement token. Never log the binding,
-client secret, token, complete connection object, or inspected route plan.
+exactly one Connectivity service binding. For a client-secret binding, obtain
+its OAuth token at `<token_service_url>/oauth/token`, pass the raw token without
+`Bearer `, cache it only until shortly before expiry, and create a new client or
+pool for the replacement token. X.509/mTLS service-binding credentials require
+consumer-side token acquisition that is not provided by open-rfc or the ARC-1
+sample. Never log the binding, client secret, private key, token, complete
+connection object, or inspected route plan.
+
+Configure the Cloud Connector side as follows:
+
+1. Connect Cloud Connector to the same BTP subaccount used by the CF
+   application. If that connection has a Location ID, pass that exact value as
+   `connectivity_socks5_location_id`.
+2. Add an **ABAP System** mapping with protocol **TCP**, not RFC or RFC SNC.
+   Set the internal host to the SAP application server reachable from Cloud
+   Connector and the internal port to its gateway port `33NN`.
+3. Choose one virtual host and one virtual port for this mapping. Do not expose
+   a host or port range. Use those exact virtual values as `gwhost` and
+   `gwserv`; they are not the internal SAP hostname and port.
+4. Create and bind one BTP Connectivity service instance to the application,
+   then restage it. Read `onpremise_proxy_host` and
+   `onpremise_socks5_proxy_port` from that binding; never substitute
+   `onpremise_proxy_rfc_port`.
+5. Keep `ashost`, `sysnr`, `client`, `user`, `passwd`, and `lang` set for the
+   actual SAP application-server identity and named-user logon. The TCP tunnel
+   changes the network route, not the RFC authentication model.
+
+The CF trust boundary is the connected subaccount and the identities permitted
+to obtain or consume Connectivity service-binding credentials. Cloud
+Connector's Trusted Applications allowlist applies to Neo, not CF. Use
+separate production and non-production subaccounts/Cloud Connector
+configurations, restrict CF org/space roles and service-binding operations,
+and keep the mapping private to the smallest deployment scope available.
 
 This preview supports named-user authentication only. It rejects the separate
 `connectivity_proxy_*` RFC-proxy route, principal propagation, SAProuter,
 message-server, and WebSocket. Cloud Connector cannot inspect a TCP mapping to
 apply an RFC resource allowlist, so the dedicated user's exact `S_RFC` role is
-the function-level enforcement point.
+the function-level enforcement point. The BTP-to-Cloud-Connector tunnel is
+TLS-protected, but open-rfc does not implement SNC; classic RFC on the internal
+Cloud-Connector-to-SAP-gateway hop has no end-to-end confidentiality or peer
+authentication. Keep that hop on a trusted segmented network. Select TCP TLS
+only when the mapped backend endpoint actually implements the corresponding TLS
+protocol; it does not add SNC to an ordinary SAP gateway.
+
+Confirm these values against SAP's current BTP Connectivity documentation for
+the TCP/SOCKS5 protocol, service-instance bindings, and Cloud Connector access
+control before each rollout.
 
 ## Principal and authorization
 

--- a/docs_page/configuration.md
+++ b/docs_page/configuration.md
@@ -30,14 +30,40 @@ derived `33NN` service. `gwhost` changes the TCP gateway endpoint while
 the SAP GUI dispatcher port (`32NN`) with the RFC gateway port (`33NN`).
 
 The first beta supports this direct application-server route. Message-server,
-SAProuter, WebSocket RFC, Cloud Connector principal propagation, SNC, and
-X.509 are unsupported options, not substitutes for this
-configuration. See [Connection routes](routes.md).
+SAProuter, Connectivity SOCKS5/TCP, WebSocket RFC, Cloud Connector RFC proxy
+and principal propagation, SNC, and X.509 remain outside the supported
+contract. See [Connection routes](routes.md).
 
 !!! danger "Classic RFC is not encrypted"
     Password-authenticated classic RFC does not provide transport encryption
     or peer authentication. Use it only on a trusted private network or inside
     a separately managed protected tunnel.
+
+## BTP Connectivity SOCKS5 preview
+
+The direct route can be placed inside a Cloud Connector TCP tunnel with these
+additional fields:
+
+| Property | Source and behavior |
+|---|---|
+| `connectivity_socks5_proxy_host` | Connectivity binding `onpremise_proxy_host`; required with port and token. |
+| `connectivity_socks5_proxy_port` | Binding `onpremise_socks5_proxy_port`; do not substitute `onpremise_proxy_rfc_port`. |
+| `connectivity_socks5_access_token` | Raw Connectivity OAuth access token without `Bearer `; caller-owned and short-lived. |
+| `connectivity_socks5_location_id` | Optional unencoded Cloud Connector location ID. |
+
+Set `gwhost` and `gwserv` to the TCP mapping's virtual host and port. Keep
+`ashost` as the actual SAP application-server identity carried by CPIC. Select
+exactly one Connectivity service binding, obtain its OAuth token with the
+binding client credentials at `<token_service_url>/oauth/token`, cache it only
+until shortly before expiry, and
+create a new client or pool for the replacement token. Never log the binding,
+client secret, token, complete connection object, or inspected route plan.
+
+This preview supports named-user authentication only. It rejects the separate
+`connectivity_proxy_*` RFC-proxy route, principal propagation, SAProuter,
+message-server, and WebSocket. Cloud Connector cannot inspect a TCP mapping to
+apply an RFC resource allowlist, so the dedicated user's exact `S_RFC` role is
+the function-level enforcement point.
 
 ## Principal and authorization
 

--- a/docs_page/routes.md
+++ b/docs_page/routes.md
@@ -81,4 +81,9 @@ together; the location ID is optional.
 The route rejects RFC-proxy parameters, principal propagation, SAProuter,
 message-server, and WebSocket combinations before socket I/O. Because a TCP
 mapping is opaque, enforce the exact RFM allowlist with the named user's
-`S_RFC` role and restrict which Cloud Foundry applications may use the mapping.
+`S_RFC` role. On Cloud Foundry the tunnel is scoped to the connected
+subaccount; Cloud Connector's Trusted Applications allowlist is Neo-only.
+Isolate production subaccounts and spaces, restrict Connectivity
+service-binding access, and expose only the exact virtual host and gateway port.
+See [Configuration](configuration.md#btp-connectivity-socks5-preview) for the
+complete mapping and credential checklist.

--- a/docs_page/routes.md
+++ b/docs_page/routes.md
@@ -7,7 +7,8 @@
 | Direct application server | Supported for the documented classic RFC/password API and representative one-run paths. Project tests do not yet cover dedicated large-data, disposition, metadata, recovery, principal-isolation, transaction, value, and contention cases on both selected SAP releases. |
 | Message server | Unsupported preview. Implemented and tested offline, but unsupported by this release. The classic route is unencrypted and trusts the configured message server to select the application server. |
 | SAProuter | Unsupported preview. Implemented and tested offline, but unsupported by this release. Routing alone does not add encryption or peer authentication. |
-| Cloud Connector / Connectivity proxy | Unsupported in the first beta. Upgrade, propagated identity, business invocation, and authentication are outside the supported boundary. |
+| Cloud Connector TCP/SOCKS5 | Unsupported preview for direct named-user classic RFC. Implemented with an explicit TCP mapping; Cloud Connector cannot enforce RFC function-module resources on this opaque route. |
+| Cloud Connector RFC proxy / principal propagation | Unsupported. The RFC-proxy endpoint is a different protocol; upgrade, propagated identity, and RFC-proxy business invocation remain outside the boundary. |
 | WebSocket RFC | Unsupported preview. The first beta fails closed before business I/O; WebSocket business invocation is outside the supported boundary. |
 | SNC, SSO, X.509 | Unsupported; parameters must be rejected before network I/O. |
 
@@ -49,3 +50,35 @@ that server. Neither leg supplies transport encryption or peer authentication.
 The route is outside this release's beta support. Do not use a successful
 preview connection as proof that a deployment is supported; consult the
 status page shipped with a later exact version before assuming this changed.
+
+## Cloud Connector TCP/SOCKS5 (unsupported preview)
+
+This route tunnels the existing direct CPIC/NI transport through the BTP
+Connectivity service's documented SOCKS5 endpoint. It requires a Cloud
+Connector TCP system mapping whose virtual host and port target the on-premise
+SAP gateway (`33NN`). It does not use `onpremise_proxy_rfc_port`.
+
+```js
+{
+  ashost: process.env.SAP_ASHOST,
+  gwhost: process.env.CC_VIRTUAL_HOST,
+  gwserv: process.env.CC_VIRTUAL_PORT,
+  client: process.env.SAP_CLIENT,
+  user: process.env.SAP_USER,
+  passwd: process.env.SAP_PASSWD,
+  connectivity_socks5_proxy_host: process.env.CONNECTIVITY_PROXY_HOST,
+  connectivity_socks5_proxy_port: process.env.CONNECTIVITY_SOCKS5_PROXY_PORT,
+  connectivity_socks5_access_token: process.env.CONNECTIVITY_ACCESS_TOKEN,
+  connectivity_socks5_location_id: process.env.CONNECTIVITY_LOCATION_ID,
+}
+```
+
+The caller obtains the raw, short-lived access token from the Connectivity
+service binding and must recreate the client or pool before it expires. Do not
+prefix the token with `Bearer `. Host, SOCKS5 port, and token are required
+together; the location ID is optional.
+
+The route rejects RFC-proxy parameters, principal propagation, SAProuter,
+message-server, and WebSocket combinations before socket I/O. Because a TCP
+mapping is opaque, enforce the exact RFM allowlist with the named user's
+`S_RFC` role and restrict which Cloud Foundry applications may use the mapping.

--- a/docs_page/safety.md
+++ b/docs_page/safety.md
@@ -13,13 +13,18 @@
 - Do not log request bodies, returned tables, raw frames, captures, destination
   credentials, or backend identity.
 - Use a dedicated least-privilege RFC user and network allowlist.
-- For the Connectivity SOCKS5 preview, restrict the Cloud Connector TCP mapping
-  to trusted applications and enforce function access in `S_RFC`; an opaque TCP
-  mapping cannot apply Cloud Connector RFC-resource allowlists.
+- For the Connectivity SOCKS5 preview, expose one exact virtual host and
+  gateway port and enforce function access in `S_RFC`; an opaque TCP mapping
+  cannot apply Cloud Connector RFC-resource allowlists. On CF, restrict access
+  to Connectivity service bindings and isolate production subaccounts and
+  spaces. The Cloud Connector Trusted Applications allowlist is Neo-only.
 - Configure finite call, pool-acquisition, pool-lifecycle, and shutdown
   deadlines. Direct connect has a fixed 10,000 ms connector bound, modern
   connection operations have a fixed 45,000 ms bound, and cancellation has no
   separate duration option; do not describe those fixed bounds as user-tunable.
+  Connectivity setup applies its bound separately to the TCP proxy connection
+  and the subsequent SOCKS5 handshake, so setup can approach twice that
+  per-phase bound before the RFC handshake begins.
 - Classify authorization or environment failure separately from protocol
   incompatibility.
 

--- a/docs_page/safety.md
+++ b/docs_page/safety.md
@@ -13,6 +13,9 @@
 - Do not log request bodies, returned tables, raw frames, captures, destination
   credentials, or backend identity.
 - Use a dedicated least-privilege RFC user and network allowlist.
+- For the Connectivity SOCKS5 preview, restrict the Cloud Connector TCP mapping
+  to trusted applications and enforce function access in `S_RFC`; an opaque TCP
+  mapping cannot apply Cloud Connector RFC-resource allowlists.
 - Configure finite call, pool-acquisition, pool-lifecycle, and shutdown
   deadlines. Direct connect has a fixed 10,000 ms connector bound, modern
   connection operations have a fixed 45,000 ms bound, and cancellation has no

--- a/docs_page/status.md
+++ b/docs_page/status.md
@@ -152,9 +152,10 @@ Verify a published beta against its public source commit, exact release tarball,
 release verification record, SBOM, and repository controls. These supply-chain
 checks do not expand the capability or platform support described above.
 
-Message-server, SAProuter, WebSocket RFC, Cloud Connector principal
-propagation, SNC, and X.509 are unsupported. Their presence in code or offline
-tests does not add them to a release support contract.
+Message-server, SAProuter, Connectivity SOCKS5/TCP, WebSocket RFC, Cloud
+Connector RFC proxy and principal propagation, SNC, and X.509 are unsupported.
+Their presence in code, offline tests, or a single-system spike does not add
+them to a release support contract.
 
 ## Public source contract
 

--- a/docs_page/troubleshooting.md
+++ b/docs_page/troubleshooting.md
@@ -26,6 +26,13 @@
   unavailable. Message-server and SAProuter previews may attempt network I/O,
   but remain outside this release's beta support.
 
+For the Connectivity SOCKS5 preview, confirm that the binding value is
+`onpremise_socks5_proxy_port`, the token has no `Bearer ` prefix, and `gwhost` /
+`gwserv` name an enabled Cloud Connector TCP virtual mapping. The RFC-proxy port
+is not a fallback. An authentication rejection is a Connectivity-token problem;
+a target rejection is a TCP mapping or application-allowlist problem; an SAP
+logon failure occurs only after both tunnel stages succeeded.
+
 For a direct route, the default RFC gateway is `33NN`, derived from `sysnr`.
 The SAP GUI dispatcher commonly uses `32NN` and is not interchangeable.
 

--- a/docs_page/troubleshooting.md
+++ b/docs_page/troubleshooting.md
@@ -30,8 +30,10 @@ For the Connectivity SOCKS5 preview, confirm that the binding value is
 `onpremise_socks5_proxy_port`, the token has no `Bearer ` prefix, and `gwhost` /
 `gwserv` name an enabled Cloud Connector TCP virtual mapping. The RFC-proxy port
 is not a fallback. An authentication rejection is a Connectivity-token problem;
-a target rejection is a TCP mapping or application-allowlist problem; an SAP
-logon failure occurs only after both tunnel stages succeeded.
+a target rejection means the virtual mapping, Location ID, subaccount/connector
+association, or internal target is unavailable. Cloud Connector's Trusted
+Applications allowlist is Neo-only and is not a CF troubleshooting control. An
+SAP logon failure occurs only after both tunnel stages succeeded.
 
 For a direct route, the default RFC gateway is `33NN`, derived from `sysnr`.
 The SAP GUI dispatcher commonly uses `32NN` and is not interchangeable.

--- a/src/compat/compatibility-owner-route.ts
+++ b/src/compat/compatibility-owner-route.ts
@@ -4,6 +4,8 @@ import { createProductionDirectDestinationSessionFactory } from
   "../destination/direct-destination-owner.js";
 import { createSapRouterDirectCpicTransportFactory } from
   "../transport/saprouter-ni.js";
+import { createConnectivitySocks5DirectCpicTransportFactory } from
+  "../transport/connectivity-socks5-ni.js";
 import {
   normalizeDirectConnectionParameters,
   type NormalizedDirectConnection,
@@ -39,6 +41,24 @@ export function planCompatibilityOwnerRoute(
         "Connectivity routes are not implemented by the archived Client/Pool facade",
       );
     }
+    if (plan.connectivitySocks5 !== undefined) {
+      const transportFactory =
+        createConnectivitySocks5DirectCpicTransportFactory({
+          proxyHost: plan.connectivitySocks5.host,
+          proxyPort: plan.connectivitySocks5.port,
+          accessToken: plan.connectivitySocks5.accessToken,
+          ...(plan.connectivitySocks5.locationId === undefined
+            ? {}
+            : { locationId: plan.connectivitySocks5.locationId }),
+        });
+      return Object.freeze({
+        kind: "direct" as const,
+        connection: normalizedDirectConnectionFromPlan(plan),
+        sessionFactory: createProductionDirectDestinationSessionFactory({
+          transportFactory,
+        }),
+      });
+    }
     if (plan.sapRouter !== undefined) {
       const transportFactory = createSapRouterDirectCpicTransportFactory(
         plan.sapRouter.routeString,
@@ -61,7 +81,11 @@ export function planCompatibilityOwnerRoute(
       "wshost connections are not implemented by the archived Client/Pool facade",
     );
   }
-  if (plan.sapRouter !== undefined || plan.connectivityProxy !== undefined) {
+  if (
+    plan.sapRouter !== undefined ||
+    plan.connectivityProxy !== undefined ||
+    plan.connectivitySocks5 !== undefined
+  ) {
     throw new Error(
       "message-server SAProuter and Connectivity routes are not implemented by the archived Client/Pool facade",
     );

--- a/src/compat/connection-parameters.ts
+++ b/src/compat/connection-parameters.ts
@@ -50,9 +50,27 @@ const RECOGNIZED_DIRECT_PARAMETER_NAMES = Object.freeze([
   "sysid",
   "group",
   "wshost",
+  "wsport",
   "saprouter",
+  "connectivity_proxy_host",
+  "connectivity_proxy_port",
+  "connectivity_proxy_authentication",
+  "connectivity_subaccount",
+  "connectivity_location_id",
+  "connectivity_socks5_proxy_host",
+  "connectivity_socks5_proxy_port",
+  "connectivity_socks5_access_token",
+  "connectivity_socks5_location_id",
+  "business_user_token",
   "snc_mode",
 ] as const);
+
+const HIDDEN_DIRECT_PARAMETER_NAMES = new Set([
+  "passwd",
+  "business_user_token",
+  "connectivity_proxy_authentication",
+  "connectivity_socks5_access_token",
+]);
 
 const ISO_TO_SAP_LANGUAGE: Readonly<Record<string, string>> = Object.freeze({
   AF: "a",
@@ -254,9 +272,10 @@ export function snapshotDirectConnectionParameters(
           `RFC connection parameter ${key} must be an own data property`,
         );
       }
+      const hidden = HIDDEN_DIRECT_PARAMETER_NAMES.has(key.toLowerCase());
       Object.defineProperty(snapshot, key, {
         configurable: false,
-        enumerable: key.toLowerCase() !== "passwd",
+        enumerable: !hidden,
         value: descriptor.value,
         writable: false,
       });

--- a/src/compat/connection-parameters.ts
+++ b/src/compat/connection-parameters.ts
@@ -69,7 +69,9 @@ const HIDDEN_DIRECT_PARAMETER_NAMES = new Set([
   "passwd",
   "business_user_token",
   "connectivity_proxy_authentication",
+  "connectivity_location_id",
   "connectivity_socks5_access_token",
+  "connectivity_socks5_location_id",
 ]);
 
 const ISO_TO_SAP_LANGUAGE: Readonly<Record<string, string>> = Object.freeze({

--- a/src/compat/connection-route.ts
+++ b/src/compat/connection-route.ts
@@ -18,6 +18,7 @@ export type ConnectionProviderCapability =
   | "named-user-authentication"
   | "principal-propagation"
   | "saprouter-routing"
+  | "connectivity-socks5-tcp"
   | "connectivity-rfc-proxy"
   | "connectivity-proxy-authorization";
 
@@ -79,12 +80,24 @@ export interface ConnectivityProxyPlan {
   readonly locationId?: string;
 }
 
+export interface ConnectivitySocks5Plan {
+  /** Connectivity binding field onpremise_proxy_host. */
+  readonly host: string;
+  /** Connectivity binding field onpremise_socks5_proxy_port. */
+  readonly port: number;
+  /** Raw, short-lived Connectivity JWT without a Bearer prefix. */
+  readonly accessToken: string;
+  /** Unencoded Cloud Connector location ID. */
+  readonly locationId?: string;
+}
+
 export interface ConnectionRoutePlan {
   readonly route: ConnectionRoute;
   readonly logon: NormalizedRfcLogon;
   readonly authentication: ConnectionAuthenticationPlan;
   readonly sapRouter?: SapRouterPlan;
   readonly connectivityProxy?: ConnectivityProxyPlan;
+  readonly connectivitySocks5?: ConnectivitySocks5Plan;
   /** Capabilities a downstream provider must prove before opening a socket. */
   readonly requiredProviderCapabilities: readonly ConnectionProviderCapability[];
 }
@@ -155,6 +168,10 @@ const CONNECTION_PARAMETER_NAMES = Object.freeze([
   "connectivity_proxy_authentication",
   "connectivity_subaccount",
   "connectivity_location_id",
+  "connectivity_socks5_proxy_host",
+  "connectivity_socks5_proxy_port",
+  "connectivity_socks5_access_token",
+  "connectivity_socks5_location_id",
   "business_user_token",
 ] as const);
 
@@ -268,7 +285,8 @@ function asciiTextParameter(
 
 function portParameter(
   input: ConnectionParameterSnapshot,
-  name: "wsport" | "connectivity_proxy_port",
+  name: "wsport" | "connectivity_proxy_port" |
+    "connectivity_socks5_proxy_port",
 ): number {
   const value = textParameter(input, name, true)!;
   if (!/^\d+$/u.test(value)) {
@@ -506,6 +524,71 @@ function planConnectivityProxy(
   });
 }
 
+function planConnectivitySocks5(
+  input: ConnectionParameterSnapshot,
+): ConnectivitySocks5Plan | undefined {
+  const hasHost = hasValue(input, "connectivity_socks5_proxy_host");
+  const hasPort = hasValue(input, "connectivity_socks5_proxy_port");
+  const hasToken = hasValue(input, "connectivity_socks5_access_token");
+  const hasLocation = hasValue(input, "connectivity_socks5_location_id");
+  if (!hasHost && !hasPort && !hasToken) {
+    if (hasLocation) {
+      throw new TypeError(
+        "connectivity_socks5_location_id requires the complete Connectivity SOCKS5 route",
+      );
+    }
+    return undefined;
+  }
+  if (!hasHost || !hasPort || !hasToken) {
+    throw new TypeError(
+      "connectivity_socks5_proxy_host, connectivity_socks5_proxy_port, and connectivity_socks5_access_token must be supplied together",
+    );
+  }
+
+  const accessToken = asciiTextParameter(
+    input,
+    "connectivity_socks5_access_token",
+    true,
+    65_536,
+  )!;
+  if (accessToken.startsWith("Bearer ")) {
+    throw new RangeError(
+      "connectivity_socks5_access_token must be a raw token without a Bearer prefix",
+    );
+  }
+  const locationId = textParameter(
+    input,
+    "connectivity_socks5_location_id",
+    false,
+  );
+  if (
+    locationId !== undefined &&
+    (Buffer.byteLength(locationId, "utf8") > 189 ||
+      /[\u0000-\u001f\u007f]/u.test(locationId))
+  ) {
+    throw new RangeError(
+      "connectivity_socks5_location_id must use at most 189 bytes without control characters",
+    );
+  }
+  const value = {
+    host: asciiTextParameter(
+      input,
+      "connectivity_socks5_proxy_host",
+      true,
+      255,
+    )!,
+    port: portParameter(input, "connectivity_socks5_proxy_port"),
+    accessToken,
+    ...(locationId === undefined ? {} : { locationId }),
+  };
+  return freezeSecretNode(value, {
+    host: value.host,
+    port: value.port,
+    accessToken: REDACTED,
+    ...(locationId === undefined ? {} : { locationId: REDACTED }),
+  });
+}
+
 function sapRouterRouteString(input: ConnectionParameterSnapshot): string | undefined {
   const value = textParameter(input, "saprouter", false);
   if (value === undefined) return undefined;
@@ -528,6 +611,12 @@ export function planConnectionRoute(
   const route = planRoute(input);
   const authentication = planAuthentication(input);
   const connectivityProxy = planConnectivityProxy(input);
+  const connectivitySocks5 = planConnectivitySocks5(input);
+  if (connectivityProxy !== undefined && connectivitySocks5 !== undefined) {
+    throw new TypeError(
+      "Connectivity RFC proxy and Connectivity SOCKS5 routes cannot be combined",
+    );
+  }
   if (
     authentication.authentication.kind === "principal-propagation" &&
     connectivityProxy === undefined
@@ -540,6 +629,23 @@ export function planConnectionRoute(
   const routeString = sapRouterRouteString(input);
   if (routeString !== undefined && route.route.kind === "websocket") {
     throw new TypeError("saprouter cannot be combined with WebSocket RFC");
+  }
+  if (connectivitySocks5 !== undefined) {
+    if (route.route.kind !== "direct") {
+      throw new TypeError(
+        "Connectivity SOCKS5 is supported only for a direct ashost route",
+      );
+    }
+    if (authentication.authentication.kind !== "named-user") {
+      throw new TypeError(
+        "Connectivity SOCKS5 requires named-user authentication",
+      );
+    }
+    if (routeString !== undefined) {
+      throw new TypeError(
+        "Connectivity SOCKS5 cannot be combined with SAProuter",
+      );
+    }
   }
   const sapRouter = routeString === undefined
     ? undefined
@@ -559,6 +665,9 @@ export function planConnectionRoute(
       required.push("connectivity-proxy-authorization");
     }
   }
+  if (connectivitySocks5 !== undefined) {
+    required.push("connectivity-socks5-tcp");
+  }
 
   return Object.freeze({
     route: route.route,
@@ -566,6 +675,7 @@ export function planConnectionRoute(
     authentication: authentication.authentication,
     ...(sapRouter === undefined ? {} : { sapRouter }),
     ...(connectivityProxy === undefined ? {} : { connectivityProxy }),
+    ...(connectivitySocks5 === undefined ? {} : { connectivitySocks5 }),
     requiredProviderCapabilities: Object.freeze(required),
   });
 }

--- a/src/compat/direct-rfc-session-provider.ts
+++ b/src/compat/direct-rfc-session-provider.ts
@@ -51,6 +51,11 @@ function directConnection(
       "direct RFC session provider requires named-user authentication",
     );
   }
+  if (plan.sapRouter !== undefined && plan.connectivitySocks5 !== undefined) {
+    throw new TypeError(
+      "direct RFC session provider cannot combine SAProuter and Connectivity SOCKS5",
+    );
+  }
   if (plan.sapRouter !== undefined && !sapRouterSupported) {
     throw new TypeError(
       "direct RFC session provider does not implement SAProuter",

--- a/src/compat/direct-rfc-session-provider.ts
+++ b/src/compat/direct-rfc-session-provider.ts
@@ -13,6 +13,7 @@ import {
 } from "./connection-parameters.js";
 import {
   normalizedDirectConnectionFromPlan,
+  type ConnectivitySocks5Plan,
   type ConnectionRoutePlan,
 } from "./connection-route.js";
 import type { RFCClientDestinationOwnerFactory } from "./rfc-client-owner-registry.js";
@@ -31,11 +32,16 @@ export interface DirectRfcSessionProviderOptions {
   readonly sapRouterTransportFactory?: (
     routeString: string,
   ) => DirectCpicTransportFactory;
+  /** Present only when a real BTP Connectivity SOCKS5 transport is composed. */
+  readonly connectivitySocks5TransportFactory?: (
+    plan: ConnectivitySocks5Plan,
+  ) => DirectCpicTransportFactory;
 }
 
 function directConnection(
   plan: ConnectionRoutePlan,
   sapRouterSupported: boolean,
+  connectivitySocks5Supported: boolean,
 ): NormalizedDirectConnection {
   if (plan.route.kind !== "direct") {
     throw new TypeError("direct RFC session provider requires a direct route");
@@ -53,6 +59,11 @@ function directConnection(
   if (plan.connectivityProxy !== undefined) {
     throw new TypeError(
       "direct RFC session provider does not implement Connectivity",
+    );
+  }
+  if (plan.connectivitySocks5 !== undefined && !connectivitySocks5Supported) {
+    throw new TypeError(
+      "direct RFC session provider does not implement Connectivity SOCKS5",
     );
   }
   return normalizedDirectConnectionFromPlan(plan);
@@ -195,12 +206,22 @@ export function createDirectRfcSessionProvider(
   const ownerFactory = options.ownerFactory;
   const operationTimeoutMs = options.operationTimeoutMs;
   const sapRouterTransportFactory = options.sapRouterTransportFactory;
+  const connectivitySocks5TransportFactory =
+    options.connectivitySocks5TransportFactory;
   if (
     sapRouterTransportFactory !== undefined &&
     typeof sapRouterTransportFactory !== "function"
   ) {
     throw new TypeError(
       "direct RFC session provider sapRouterTransportFactory must be a function",
+    );
+  }
+  if (
+    connectivitySocks5TransportFactory !== undefined &&
+    typeof connectivitySocks5TransportFactory !== "function"
+  ) {
+    throw new TypeError(
+      "direct RFC session provider connectivitySocks5TransportFactory must be a function",
     );
   }
   const provider: RfcSessionProvider = {
@@ -210,11 +231,15 @@ export function createDirectRfcSessionProvider(
       ...(sapRouterTransportFactory === undefined
         ? []
         : ["saprouter-routing"] as const),
+      ...(connectivitySocks5TransportFactory === undefined
+        ? []
+        : ["connectivity-socks5-tcp"] as const),
     ]),
     async open(plan) {
       const connection = directConnection(
         plan,
         sapRouterTransportFactory !== undefined,
+        connectivitySocks5TransportFactory !== undefined,
       );
       let transportFactory: DirectCpicTransportFactory | undefined;
       if (plan.sapRouter !== undefined) {
@@ -226,6 +251,18 @@ export function createDirectRfcSessionProvider(
         if (typeof transportFactory !== "function") {
           throw new TypeError(
             "sapRouterTransportFactory must return a transport function",
+          );
+        }
+      }
+      if (plan.connectivitySocks5 !== undefined) {
+        transportFactory = Reflect.apply(
+          connectivitySocks5TransportFactory!,
+          undefined,
+          [plan.connectivitySocks5],
+        ) as DirectCpicTransportFactory;
+        if (typeof transportFactory !== "function") {
+          throw new TypeError(
+            "connectivitySocks5TransportFactory must return a transport function",
           );
         }
       }

--- a/src/compat/message-server-direct-session-factory.ts
+++ b/src/compat/message-server-direct-session-factory.ts
@@ -37,7 +37,11 @@ function messagePlan(options: MessageServerDirectSessionFactoryOptions): void {
   if (options.plan.authentication.kind !== "named-user") {
     throw new TypeError("message-server session factory requires named-user authentication");
   }
-  if (options.plan.sapRouter !== undefined || options.plan.connectivityProxy !== undefined) {
+  if (
+    options.plan.sapRouter !== undefined ||
+    options.plan.connectivityProxy !== undefined ||
+    options.plan.connectivitySocks5 !== undefined
+  ) {
     throw new TypeError(
       "message-server session factory does not implement SAProuter or Connectivity",
     );

--- a/src/compat/message-server-rfc-session-provider.ts
+++ b/src/compat/message-server-rfc-session-provider.ts
@@ -478,7 +478,10 @@ export function createMessageServerRfcSessionProvider(
           "message-server provider supports only direct and message-server routes",
         );
       }
-      if (plan.connectivityProxy !== undefined) {
+      if (
+        plan.connectivityProxy !== undefined ||
+        plan.connectivitySocks5 !== undefined
+      ) {
         throw new TypeError(
           "message-server resolution does not implement Connectivity",
         );

--- a/src/compat/node-rfc-client.ts
+++ b/src/compat/node-rfc-client.ts
@@ -35,6 +35,8 @@ import {
 import type { RfcFunctionInterface } from "../metadata/rfc-function-interface.js";
 import type { RfcStructureDefinition } from "../metadata/rfc-structure-definition.js";
 import { NiTransportError } from "../transport/ni-socket.js";
+import { ConnectivitySocks5Error } from
+  "../transport/connectivity-socks5-tunnel.js";
 import { SapRouterTransportError } from "../transport/saprouter-tunnel.js";
 import {
   snapshotClassicInt8Mode,
@@ -201,6 +203,33 @@ export function projectNodeRfcPublicError(error: unknown): unknown {
         ? RFCErrorCode.RFC_TIMEOUT
         : RFCErrorCode.RFC_COMMUNICATION_FAILURE,
       codeString: timeout ? "RFC_TIMEOUT" : "RFC_COMMUNICATION_FAILURE",
+      key: cause.code,
+    });
+  }
+  if (cause instanceof ConnectivitySocks5Error) {
+    const canceled = cause.code === "CONNECTIVITY_SOCKS5_ABORTED";
+    const timeout = cause.code === "CONNECTIVITY_SOCKS5_CONNECT_TIMEOUT" ||
+      cause.code === "CONNECTIVITY_SOCKS5_TIMEOUT";
+    const code = canceled
+      ? RFCErrorCode.RFC_CANCELED
+      : timeout
+        ? RFCErrorCode.RFC_TIMEOUT
+        : RFCErrorCode.RFC_COMMUNICATION_FAILURE;
+    const codeString = canceled
+      ? "RFC_CANCELED"
+      : timeout
+        ? "RFC_TIMEOUT"
+        : "RFC_COMMUNICATION_FAILURE";
+    const message = canceled
+      ? "Connectivity SOCKS5 setup was canceled."
+      : timeout
+        ? "Connectivity SOCKS5 setup timed out."
+        : "Connectivity SOCKS5 setup failed.";
+    return new RFCError(message, {
+      name: "RfcLibError",
+      group: 4,
+      code,
+      codeString,
       key: cause.code,
     });
   }

--- a/src/compat/node-rfc-library.ts
+++ b/src/compat/node-rfc-library.ts
@@ -58,6 +58,9 @@ import {
 import {
   createSapRouterDirectCpicTransportFactory,
 } from "../transport/saprouter-ni.js";
+import {
+  createConnectivitySocks5DirectCpicTransportFactory,
+} from "../transport/connectivity-socks5-ni.js";
 import { NiTransportError } from "../transport/ni-socket.js";
 
 export interface RFCInputParams {
@@ -925,6 +928,15 @@ export class RFCClient {
       },
       operationTimeoutMs: MODERN_OPERATION_TIMEOUT_MS,
       sapRouterTransportFactory: createSapRouterDirectCpicTransportFactory,
+      connectivitySocks5TransportFactory: (plan) =>
+        createConnectivitySocks5DirectCpicTransportFactory({
+          proxyHost: plan.host,
+          proxyPort: plan.port,
+          accessToken: plan.accessToken,
+          ...(plan.locationId === undefined
+            ? {}
+            : { locationId: plan.locationId }),
+        }),
     });
     bindRFCClientSessionProvider(
       this,

--- a/src/compat/rfc-client-session-route.ts
+++ b/src/compat/rfc-client-session-route.ts
@@ -30,6 +30,10 @@ const RFC_CLIENT_ROUTE_PARAMETERS = Object.freeze([
   "connectivity_proxy_authentication",
   "connectivity_subaccount",
   "connectivity_location_id",
+  "connectivity_socks5_proxy_host",
+  "connectivity_socks5_proxy_port",
+  "connectivity_socks5_access_token",
+  "connectivity_socks5_location_id",
   "business_user_token",
 ] as const);
 

--- a/src/compat/rfc-session-provider-binding.ts
+++ b/src/compat/rfc-session-provider-binding.ts
@@ -17,6 +17,7 @@ const PROVIDER_CAPABILITIES: ReadonlySet<ConnectionProviderCapability> =
     "named-user-authentication",
     "principal-propagation",
     "saprouter-routing",
+    "connectivity-socks5-tcp",
     "connectivity-rfc-proxy",
     "connectivity-proxy-authorization",
   ]);

--- a/src/transport/connectivity-socks5-ni.ts
+++ b/src/transport/connectivity-socks5-ni.ts
@@ -1,0 +1,178 @@
+import { types as nodeUtilTypes } from "node:util";
+
+import type { DirectCpicTransportFactory } from "../client/direct-cpic-session.js";
+import { NiSocketTransport, type NiConnectedSocket } from "./ni-socket.js";
+import {
+  admitConnectivitySocks5Config,
+  connectConnectivitySocks5Tunnel,
+  type AdmittedConnectivitySocks5Config,
+  type ConnectivitySocks5Socket,
+  type EstablishedConnectivitySocks5Tunnel,
+} from "./connectivity-socks5-tunnel.js";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const ALLOWED_PROXY_PROPERTIES = Object.freeze(new Set([
+  "proxyHost",
+  "proxyPort",
+  "accessToken",
+  "locationId",
+  "timeoutMs",
+  "maxBufferedBytes",
+]));
+
+export interface ConnectivitySocks5DirectCpicProxyInput {
+  /** Connectivity binding host and `onpremise_socks5_proxy_port`. */
+  readonly proxyHost: string;
+  readonly proxyPort: number;
+  /** Raw Connectivity access token, without `Bearer `. */
+  readonly accessToken: string;
+  readonly locationId?: string;
+  /** Optional fixed per-phase timeout; otherwise the CPIC connect timeout wins. */
+  readonly timeoutMs?: number;
+  readonly maxBufferedBytes?: number;
+}
+
+export type ConnectivitySocks5TunnelConnector = (
+  config: AdmittedConnectivitySocks5Config,
+  signal?: AbortSignal,
+) => Promise<EstablishedConnectivitySocks5Tunnel>;
+
+export interface ConnectivitySocks5NiDependencies {
+  readonly connectTunnel?: ConnectivitySocks5TunnelConnector;
+}
+
+interface FixedProxySnapshot {
+  readonly proxyHost: string;
+  readonly proxyPort: number;
+  readonly accessToken: string;
+  readonly locationId: string | undefined;
+  readonly timeoutMs: number | undefined;
+  readonly maxBufferedBytes: number;
+}
+
+function ownProxyValues(input: unknown): ReadonlyMap<string, unknown> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw new TypeError("Connectivity SOCKS5 proxy options must be a plain object");
+  }
+  if (nodeUtilTypes.isProxy(input)) {
+    throw new TypeError("Connectivity SOCKS5 proxy options must not be a Proxy");
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError("Connectivity SOCKS5 proxy options must be a plain object");
+  }
+  const values = new Map<string, unknown>();
+  for (const key of Reflect.ownKeys(input)) {
+    if (typeof key !== "string") {
+      throw new TypeError("Connectivity SOCKS5 proxy options do not accept symbols");
+    }
+    if (!ALLOWED_PROXY_PROPERTIES.has(key)) {
+      throw new TypeError(
+        `Connectivity SOCKS5 proxy options have unsupported property ${key}`,
+      );
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(input, key);
+    if (descriptor === undefined || !("value" in descriptor)) {
+      throw new TypeError(`${key} must be an own data property`);
+    }
+    values.set(key, descriptor.value);
+  }
+  return values;
+}
+
+function snapshotProxy(input: ConnectivitySocks5DirectCpicProxyInput): FixedProxySnapshot {
+  const values = ownProxyValues(input);
+  const candidate: Record<string, unknown> = {
+    proxyHost: values.get("proxyHost"),
+    proxyPort: values.get("proxyPort"),
+    targetHost: "validation.invalid",
+    targetPort: 1,
+    accessToken: values.get("accessToken"),
+  };
+  for (const optional of [
+    "locationId",
+    "timeoutMs",
+    "maxBufferedBytes",
+  ] as const) {
+    if (values.has(optional)) candidate[optional] = values.get(optional);
+  }
+  const admitted = admitConnectivitySocks5Config(candidate);
+  return Object.freeze({
+    proxyHost: admitted.proxyHost,
+    proxyPort: admitted.proxyPort,
+    accessToken: admitted.accessToken,
+    locationId: admitted.locationId,
+    timeoutMs: values.has("timeoutMs") ? admitted.timeoutMs : undefined,
+    maxBufferedBytes: admitted.maxBufferedBytes,
+  });
+}
+
+function connectedSocket(socket: ConnectivitySocks5Socket): NiConnectedSocket {
+  return socket as unknown as NiConnectedSocket;
+}
+
+/**
+ * Route classic CPIC/NI through an explicitly configured Connectivity TCP
+ * mapping. This intentionally does not consume the distinct RFC proxy port.
+ */
+export function createConnectivitySocks5DirectCpicTransportFactory(
+  proxyInput: ConnectivitySocks5DirectCpicProxyInput,
+  dependencies: ConnectivitySocks5NiDependencies = {},
+): DirectCpicTransportFactory {
+  const proxy = snapshotProxy(proxyInput);
+  if (typeof dependencies !== "object" || dependencies === null) {
+    throw new TypeError("Connectivity SOCKS5 NI dependencies must be an object");
+  }
+  const connectTunnel = dependencies.connectTunnel ?? connectConnectivitySocks5Tunnel;
+  if (typeof connectTunnel !== "function") {
+    throw new TypeError("Connectivity SOCKS5 tunnel connector must be a function");
+  }
+
+  return async (options, signal): Promise<NiSocketTransport> => {
+    const config = admitConnectivitySocks5Config({
+      proxyHost: proxy.proxyHost,
+      proxyPort: proxy.proxyPort,
+      targetHost: options.host,
+      targetPort: options.port,
+      accessToken: proxy.accessToken,
+      ...(proxy.locationId === undefined ? {} : { locationId: proxy.locationId }),
+      timeoutMs: proxy.timeoutMs ?? options.connectTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxBufferedBytes: proxy.maxBufferedBytes,
+    });
+    let socket: ConnectivitySocks5Socket | undefined;
+    let initialData: Buffer | undefined;
+    try {
+      const established = await Reflect.apply(connectTunnel, undefined, [
+        config,
+        signal,
+      ]) as EstablishedConnectivitySocks5Tunnel;
+      if (typeof established !== "object" || established === null) {
+        throw new TypeError(
+          "Connectivity SOCKS5 tunnel connector must return a tunnel",
+        );
+      }
+      socket = established.socket;
+      if (!Buffer.isBuffer(established.initialData)) {
+        throw new TypeError(
+          "Connectivity SOCKS5 tunnel connector must return buffered initialData",
+        );
+      }
+      initialData = established.initialData;
+      const transport = NiSocketTransport.adopt({
+        socket: connectedSocket(socket),
+        initialData,
+        maxPayloadLength: options.maxPayloadLength,
+        maxQueuedPayloadLength: options.maxQueuedPayloadLength,
+        maxQueuedFrameCount: options.maxQueuedFrameCount,
+        writeTimeoutMs: options.writeTimeoutMs,
+        closeTimeoutMs: options.closeTimeoutMs,
+      }, signal);
+      initialData.fill(0);
+      return transport;
+    } catch (error) {
+      initialData?.fill(0);
+      try { socket?.destroy(); } catch { /* handoff failure wins */ }
+      throw error;
+    }
+  };
+}

--- a/src/transport/connectivity-socks5-tunnel.ts
+++ b/src/transport/connectivity-socks5-tunnel.ts
@@ -11,6 +11,7 @@ const JWT_AUTHENTICATION_VERSION = 0x01;
 const CONNECT_COMMAND = 0x01;
 const DOMAIN_ADDRESS = 0x03;
 const IPV4_ADDRESS = 0x01;
+const IPV6_ADDRESS = 0x04;
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_MAX_BUFFERED_BYTES = 16_384;
@@ -682,6 +683,11 @@ export function establishConnectivitySocks5Tunnel(
           const responseLength = 7 + domainLength;
           if (buffered.length < responseLength) return;
           succeed(responseLength);
+          return;
+        }
+        if (addressType === IPV6_ADDRESS) {
+          if (buffered.length < 22) return;
+          succeed(22);
           return;
         }
         fail(new ConnectivitySocks5Error(

--- a/src/transport/connectivity-socks5-tunnel.ts
+++ b/src/transport/connectivity-socks5-tunnel.ts
@@ -1,0 +1,938 @@
+import {
+  createConnection,
+  isIP,
+  type Socket,
+} from "node:net";
+import { inspect, types as nodeUtilTypes } from "node:util";
+
+const SOCKS_VERSION = 0x05;
+const JWT_AUTHENTICATION_METHOD = 0x80;
+const JWT_AUTHENTICATION_VERSION = 0x01;
+const CONNECT_COMMAND = 0x01;
+const DOMAIN_ADDRESS = 0x03;
+const IPV4_ADDRESS = 0x01;
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_BUFFERED_BYTES = 16_384;
+const MAX_TIMEOUT_MS = 300_000;
+const MAX_BUFFERED_BYTES = 1_048_576;
+const MAX_ACCESS_TOKEN_BYTES = 65_536;
+const NO_TIMER = Symbol("no Connectivity SOCKS5 timer");
+const CUSTOM_INSPECT = inspect.custom;
+
+const ALLOWED_CONFIG_PROPERTIES = Object.freeze(new Set([
+  "proxyHost",
+  "proxyPort",
+  "targetHost",
+  "targetPort",
+  "accessToken",
+  "locationId",
+  "timeoutMs",
+  "maxBufferedBytes",
+]));
+const ADMITTED_CONFIGS = new WeakSet<object>();
+
+export type ConnectivitySocks5ErrorCode =
+  | "CONNECTIVITY_SOCKS5_ABORTED"
+  | "CONNECTIVITY_SOCKS5_AUTHENTICATION_REJECTED"
+  | "CONNECTIVITY_SOCKS5_CONNECTION_CLOSED"
+  | "CONNECTIVITY_SOCKS5_CONNECT_FAILED"
+  | "CONNECTIVITY_SOCKS5_CONNECT_REJECTED"
+  | "CONNECTIVITY_SOCKS5_CONNECT_TIMEOUT"
+  | "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR"
+  | "CONNECTIVITY_SOCKS5_TIMEOUT"
+  | "CONNECTIVITY_SOCKS5_WRITE_FAILED";
+
+/** A bounded failure that never includes tokens, locations, or endpoint names. */
+export class ConnectivitySocks5Error extends Error {
+  readonly code: ConnectivitySocks5ErrorCode;
+  readonly replyCode: number | undefined;
+
+  constructor(
+    code: ConnectivitySocks5ErrorCode,
+    message: string,
+    replyCode?: number,
+  ) {
+    super(message);
+    this.name = "ConnectivitySocks5Error";
+    this.code = code;
+    this.replyCode = replyCode;
+    const safe = (): Readonly<Record<string, unknown>> => Object.freeze({
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      ...(this.replyCode === undefined ? {} : { replyCode: this.replyCode }),
+    });
+    Object.defineProperty(this, "toJSON", {
+      configurable: false,
+      enumerable: false,
+      value: safe,
+      writable: false,
+    });
+    Object.defineProperty(this, CUSTOM_INSPECT, {
+      configurable: false,
+      enumerable: false,
+      value: safe,
+      writable: false,
+    });
+  }
+}
+
+export interface ConnectivitySocks5ConfigInput {
+  /** Host and SOCKS5 port from the Connectivity binding (normally 20004). */
+  readonly proxyHost: string;
+  readonly proxyPort: number;
+  /** Cloud Connector TCP virtual host and virtual port; never resolved locally. */
+  readonly targetHost: string;
+  readonly targetPort: number;
+  /** Raw Connectivity service JWT. Do not include a `Bearer ` prefix. */
+  readonly accessToken: string;
+  /** Unencoded Cloud Connector location ID. */
+  readonly locationId?: string;
+  readonly timeoutMs?: number;
+  readonly maxBufferedBytes?: number;
+}
+
+export interface AdmittedConnectivitySocks5Config {
+  readonly proxyHost: string;
+  readonly proxyPort: number;
+  readonly targetHost: string;
+  readonly targetPort: number;
+  readonly accessToken: string;
+  readonly locationId: string | undefined;
+  readonly timeoutMs: number;
+  readonly maxBufferedBytes: number;
+}
+
+/** Minimal connected byte stream shared by net.Socket and compatible streams. */
+export interface ConnectivitySocks5Socket {
+  readonly destroyed?: boolean;
+  write(
+    chunk: Uint8Array,
+    callback: (error?: Error | null) => void,
+  ): boolean;
+  pause(): unknown;
+  destroy(): unknown;
+  on(event: "data", listener: (chunk: unknown) => void): unknown;
+  on(event: "error", listener: (error: unknown) => void): unknown;
+  on(event: "end" | "close", listener: () => void): unknown;
+  removeListener(event: "data", listener: (chunk: unknown) => void): unknown;
+  removeListener(event: "error", listener: (error: unknown) => void): unknown;
+  removeListener(event: "end" | "close", listener: () => void): unknown;
+}
+
+export type ConnectivitySocks5TimerHandle = unknown;
+
+export interface ConnectivitySocks5TimerScheduler {
+  setTimeout(
+    callback: () => void,
+    delayMs: number,
+  ): ConnectivitySocks5TimerHandle;
+  clearTimeout(handle: ConnectivitySocks5TimerHandle): void;
+}
+
+const SYSTEM_TIMER_SCHEDULER: ConnectivitySocks5TimerScheduler = Object.freeze({
+  setTimeout(callback: () => void, delayMs: number): NodeJS.Timeout {
+    return setTimeout(callback, delayMs);
+  },
+  clearTimeout(handle: ConnectivitySocks5TimerHandle): void {
+    clearTimeout(handle as NodeJS.Timeout);
+  },
+});
+
+export interface EstablishedConnectivitySocks5Tunnel {
+  /** Paused stream. Attach the target protocol consumer before resuming it. */
+  readonly socket: ConnectivitySocks5Socket;
+  /** Bytes received after the CONNECT response in the same data event. */
+  readonly initialData: Buffer;
+}
+
+export interface ConnectivitySocks5ProxyConnectOptions {
+  readonly proxyHost: string;
+  readonly proxyPort: number;
+  readonly timeoutMs: number;
+  readonly signal: AbortSignal | undefined;
+  readonly scheduler: ConnectivitySocks5TimerScheduler;
+}
+
+export type ConnectivitySocks5ProxyConnector = (
+  options: ConnectivitySocks5ProxyConnectOptions,
+) => Promise<ConnectivitySocks5Socket>;
+
+export interface ConnectivitySocks5ConnectionDependencies {
+  readonly connect?: ConnectivitySocks5ProxyConnector;
+  readonly scheduler?: ConnectivitySocks5TimerScheduler;
+}
+
+function plainRecord(input: unknown): Readonly<Record<PropertyKey, unknown>> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw new TypeError("Connectivity SOCKS5 configuration must be a plain object");
+  }
+  if (nodeUtilTypes.isProxy(input)) {
+    throw new TypeError("Connectivity SOCKS5 configuration must not be a Proxy");
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError("Connectivity SOCKS5 configuration must be a plain object");
+  }
+  return input as Readonly<Record<PropertyKey, unknown>>;
+}
+
+function ownDataProperties(
+  input: Readonly<Record<PropertyKey, unknown>>,
+): ReadonlyMap<string, unknown> {
+  const values = new Map<string, unknown>();
+  for (const key of Reflect.ownKeys(input)) {
+    if (typeof key !== "string") {
+      throw new TypeError("Connectivity SOCKS5 configuration does not accept symbol properties");
+    }
+    if (!ALLOWED_CONFIG_PROPERTIES.has(key)) {
+      throw new TypeError(
+        `Connectivity SOCKS5 configuration has unsupported property ${key}`,
+      );
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(input, key);
+    if (descriptor === undefined || !("value" in descriptor)) {
+      throw new TypeError(`${key} must be an own data property`);
+    }
+    values.set(key, descriptor.value);
+  }
+  return values;
+}
+
+function required(
+  values: ReadonlyMap<string, unknown>,
+  field: string,
+): unknown {
+  if (!values.has(field)) {
+    throw new TypeError(`${field} must be an own data property`);
+  }
+  return values.get(field);
+}
+
+function host(
+  value: unknown,
+  field: "proxyHost" | "targetHost",
+  ipv6Allowed: boolean,
+): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${field} must be a non-empty host name or IP address`);
+  }
+  let candidate = value;
+  let bracketed = false;
+  if (candidate.startsWith("[") || candidate.endsWith("]")) {
+    if (!(candidate.startsWith("[") && candidate.endsWith("]"))) {
+      throw new RangeError(`${field} contains an invalid IP literal`);
+    }
+    bracketed = true;
+    candidate = candidate.slice(1, -1);
+  }
+  const version = isIP(candidate);
+  if (bracketed && version !== 6) {
+    throw new RangeError(`${field} contains an invalid bracketed IPv6 literal`);
+  }
+  if (version === 6) {
+    if (!ipv6Allowed) {
+      throw new RangeError(
+        "targetHost cannot be IPv6 because the SAP Connectivity SOCKS5 endpoint documents only IPv4 and DOMAIN targets",
+      );
+    }
+    return candidate;
+  }
+  if (version === 4) return candidate;
+  if (/^\d+(?:\.\d+){3}$/u.test(candidate)) {
+    throw new RangeError(`${field} contains an invalid IPv4 address`);
+  }
+  const normalized = candidate.endsWith(".")
+    ? candidate.slice(0, -1)
+    : candidate;
+  if (
+    normalized.length === 0 ||
+    normalized.length > 253 ||
+    !/^[A-Za-z0-9.-]+$/u.test(normalized) ||
+    normalized.includes("..")
+  ) {
+    throw new RangeError(`${field} contains an invalid host name`);
+  }
+  for (const label of normalized.split(".")) {
+    if (
+      label.length === 0 ||
+      label.length > 63 ||
+      !/^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/u.test(label)
+    ) {
+      throw new RangeError(`${field} contains an invalid host name`);
+    }
+  }
+  return normalized;
+}
+
+function port(value: unknown, field: "proxyPort" | "targetPort"): number {
+  if (
+    !Number.isSafeInteger(value) ||
+    (value as number) < 1 ||
+    (value as number) > 65_535
+  ) {
+    throw new RangeError(`${field} must be an integer in 1..65535`);
+  }
+  return value as number;
+}
+
+function boundedInteger(
+  value: unknown,
+  field: string,
+  minimum: number,
+  maximum: number,
+): number {
+  if (
+    !Number.isSafeInteger(value) ||
+    (value as number) < minimum ||
+    (value as number) > maximum
+  ) {
+    throw new RangeError(`${field} must be an integer in ${minimum}..${maximum}`);
+  }
+  return value as number;
+}
+
+function accessToken(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    !/^[\x21-\x7e]+$/u.test(value) ||
+    Buffer.byteLength(value, "ascii") > MAX_ACCESS_TOKEN_BYTES
+  ) {
+    throw new RangeError(
+      `accessToken must be 1..${MAX_ACCESS_TOKEN_BYTES} visible ASCII bytes without a Bearer prefix`,
+    );
+  }
+  return value;
+}
+
+function locationId(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 189 ||
+    /[\u0000-\u001f\u007f]/u.test(value)
+  ) {
+    throw new RangeError("locationId must be non-empty text without control characters");
+  }
+  const rawLength = Buffer.byteLength(value, "utf8");
+  if (rawLength > 189) {
+    throw new RangeError(
+      "locationId is too long after the required base64 encoding",
+    );
+  }
+  return value;
+}
+
+function safeConfigView(
+  config: AdmittedConnectivitySocks5Config,
+): Readonly<Record<string, unknown>> {
+  return Object.freeze({
+    proxyHost: "<redacted>",
+    proxyPort: config.proxyPort,
+    targetHost: "<redacted>",
+    targetPort: config.targetPort,
+    accessToken: "<redacted>",
+    locationId: config.locationId === undefined ? undefined : "<redacted>",
+    timeoutMs: config.timeoutMs,
+    maxBufferedBytes: config.maxBufferedBytes,
+  });
+}
+
+/** Validate and snapshot every byte-affecting field before network I/O. */
+export function admitConnectivitySocks5Config(
+  input: ConnectivitySocks5ConfigInput | Readonly<Record<string, unknown>>,
+): AdmittedConnectivitySocks5Config {
+  const values = ownDataProperties(plainRecord(input));
+  const normalized = {
+    proxyHost: host(required(values, "proxyHost"), "proxyHost", true),
+    proxyPort: port(required(values, "proxyPort"), "proxyPort"),
+    targetHost: host(required(values, "targetHost"), "targetHost", false),
+    targetPort: port(required(values, "targetPort"), "targetPort"),
+    accessToken: accessToken(required(values, "accessToken")),
+    locationId: locationId(values.get("locationId")),
+    timeoutMs: boundedInteger(
+      values.get("timeoutMs") ?? DEFAULT_TIMEOUT_MS,
+      "timeoutMs",
+      1,
+      MAX_TIMEOUT_MS,
+    ),
+    maxBufferedBytes: boundedInteger(
+      values.get("maxBufferedBytes") ?? DEFAULT_MAX_BUFFERED_BYTES,
+      "maxBufferedBytes",
+      8,
+      MAX_BUFFERED_BYTES,
+    ),
+  } satisfies AdmittedConnectivitySocks5Config;
+  Object.defineProperty(normalized, "toJSON", {
+    configurable: false,
+    enumerable: false,
+    value: (): Readonly<Record<string, unknown>> => safeConfigView(normalized),
+    writable: false,
+  });
+  Object.defineProperty(normalized, CUSTOM_INSPECT, {
+    configurable: false,
+    enumerable: false,
+    value: (): Readonly<Record<string, unknown>> => safeConfigView(normalized),
+    writable: false,
+  });
+  Object.freeze(normalized);
+  ADMITTED_CONFIGS.add(normalized);
+  return normalized;
+}
+
+export function assertAdmittedConnectivitySocks5Config(
+  input: unknown,
+): asserts input is AdmittedConnectivitySocks5Config {
+  if (typeof input !== "object" || input === null || !ADMITTED_CONFIGS.has(input)) {
+    throw new TypeError(
+      "Connectivity SOCKS5 configuration must come from admitConnectivitySocks5Config",
+    );
+  }
+}
+
+function validateSocket(socket: unknown): asserts socket is ConnectivitySocks5Socket {
+  if (typeof socket !== "object" || socket === null) {
+    throw new TypeError("Connectivity SOCKS5 socket must be a connected byte stream");
+  }
+  for (const method of [
+    "write",
+    "pause",
+    "destroy",
+    "on",
+    "removeListener",
+  ] as const) {
+    if (typeof (socket as Record<string, unknown>)[method] !== "function") {
+      throw new TypeError("Connectivity SOCKS5 socket must be a connected byte stream");
+    }
+  }
+}
+
+function signalAborted(signal: AbortSignal | undefined): boolean {
+  // AbortSignal is mutable across async and caller-controlled boundaries.
+  return signal?.aborted === true;
+}
+
+function schedulerFunctions(
+  scheduler: ConnectivitySocks5TimerScheduler,
+): {
+  readonly set: (
+    callback: () => void,
+    delayMs: number,
+  ) => ConnectivitySocks5TimerHandle;
+  readonly clear: (handle: ConnectivitySocks5TimerHandle) => void;
+} {
+  if (typeof scheduler !== "object" || scheduler === null) {
+    throw new TypeError("Connectivity SOCKS5 scheduler must be an object");
+  }
+  const set = scheduler.setTimeout;
+  const clear = scheduler.clearTimeout;
+  if (typeof set !== "function" || typeof clear !== "function") {
+    throw new TypeError(
+      "Connectivity SOCKS5 scheduler must provide setTimeout and clearTimeout",
+    );
+  }
+  return Object.freeze({
+    set: (callback: () => void, delayMs: number): ConnectivitySocks5TimerHandle =>
+      Reflect.apply(set, scheduler, [callback, delayMs]) as ConnectivitySocks5TimerHandle,
+    clear: (handle: ConnectivitySocks5TimerHandle): void => {
+      Reflect.apply(clear, scheduler, [handle]);
+    },
+  });
+}
+
+function authenticationRequest(
+  config: AdmittedConnectivitySocks5Config,
+): Buffer {
+  const token = Buffer.from(config.accessToken, "ascii");
+  const location = config.locationId === undefined
+    ? Buffer.alloc(0)
+    : Buffer.from(Buffer.from(config.locationId, "utf8").toString("base64"), "ascii");
+  const request = Buffer.alloc(1 + 4 + token.length + 1 + location.length);
+  request[0] = JWT_AUTHENTICATION_VERSION;
+  request.writeUInt32BE(token.length, 1);
+  token.copy(request, 5);
+  request[5 + token.length] = location.length;
+  location.copy(request, 6 + token.length);
+  token.fill(0);
+  location.fill(0);
+  return request;
+}
+
+function ipv4Bytes(hostName: string): Buffer | undefined {
+  if (isIP(hostName) !== 4) return undefined;
+  return Buffer.from(hostName.split(".").map((octet) => Number(octet)));
+}
+
+function connectRequest(
+  config: AdmittedConnectivitySocks5Config,
+): Buffer {
+  const ipv4 = ipv4Bytes(config.targetHost);
+  let request: Buffer;
+  if (ipv4 !== undefined) {
+    request = Buffer.alloc(4 + 4 + 2);
+    request.set([SOCKS_VERSION, CONNECT_COMMAND, 0x00, IPV4_ADDRESS], 0);
+    ipv4.copy(request, 4);
+    request.writeUInt16BE(config.targetPort, 8);
+    ipv4.fill(0);
+    return request;
+  }
+  const domain = Buffer.from(config.targetHost, "ascii");
+  // Admission already constrains a normalized domain to 1..253 ASCII bytes.
+  request = Buffer.alloc(5 + domain.length + 2);
+  request.set([SOCKS_VERSION, CONNECT_COMMAND, 0x00, DOMAIN_ADDRESS, domain.length], 0);
+  domain.copy(request, 5);
+  request.writeUInt16BE(config.targetPort, 5 + domain.length);
+  domain.fill(0);
+  return request;
+}
+
+type HandshakePhase =
+  | "method-response"
+  | "authentication-response"
+  | "connect-response";
+
+/**
+ * Negotiate SAP's documented method 0x80 JWT SOCKS5 extension on an already
+ * connected stream. This function is for the binding's SOCKS5/TCP endpoint,
+ * not the distinct RFC/LDAP proxy endpoint.
+ */
+export function establishConnectivitySocks5Tunnel(
+  socket: ConnectivitySocks5Socket,
+  config: AdmittedConnectivitySocks5Config,
+  signal?: AbortSignal,
+  scheduler: ConnectivitySocks5TimerScheduler = SYSTEM_TIMER_SCHEDULER,
+): Promise<EstablishedConnectivitySocks5Tunnel> {
+  validateSocket(socket);
+  assertAdmittedConnectivitySocks5Config(config);
+  const timers = schedulerFunctions(scheduler);
+  if (signalAborted(signal)) {
+    try { socket.destroy(); } catch { /* rejection remains authoritative */ }
+    return Promise.reject(new ConnectivitySocks5Error(
+      "CONNECTIVITY_SOCKS5_ABORTED",
+      "Connectivity SOCKS5 setup was aborted",
+    ));
+  }
+
+  return new Promise<EstablishedConnectivitySocks5Tunnel>((resolve, reject) => {
+    let settled = false;
+    let phase: HandshakePhase = "method-response";
+    let buffered = Buffer.alloc(0);
+    let timer: ConnectivitySocks5TimerHandle | typeof NO_TIMER = NO_TIMER;
+    const pendingWrites = new Set<Buffer>();
+
+    const clearSensitiveWrites = (): void => {
+      for (const frame of pendingWrites) frame.fill(0);
+      pendingWrites.clear();
+    };
+    const cleanup = (): void => {
+      try { socket.removeListener("data", onData); } catch { /* best effort */ }
+      try { socket.removeListener("error", onError); } catch { /* best effort */ }
+      try { socket.removeListener("end", onEnd); } catch { /* best effort */ }
+      try { socket.removeListener("close", onClose); } catch { /* best effort */ }
+      try { signal?.removeEventListener("abort", onAbort); } catch { /* best effort */ }
+      if (timer !== NO_TIMER) {
+        const handle = timer;
+        timer = NO_TIMER;
+        try { timers.clear(handle); } catch { /* best effort */ }
+      }
+    };
+    const fail = (error: ConnectivitySocks5Error): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      clearSensitiveWrites();
+      buffered.fill(0);
+      buffered = Buffer.alloc(0);
+      try { socket.destroy(); } catch { /* failure remains authoritative */ }
+      reject(error);
+    };
+    const succeed = (responseLength: number): void => {
+      if (settled) return;
+      const initialData = Buffer.from(buffered.subarray(responseLength));
+      buffered.fill(0);
+      buffered = Buffer.alloc(0);
+      try {
+        socket.pause();
+      } catch {
+        initialData.fill(0);
+        fail(new ConnectivitySocks5Error(
+          "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+          "Connectivity SOCKS5 socket could not be paused for handoff",
+        ));
+        return;
+      }
+      settled = true;
+      cleanup();
+      clearSensitiveWrites();
+      resolve(Object.freeze({ socket, initialData }));
+    };
+    const send = (frame: Buffer): void => {
+      if (settled) {
+        frame.fill(0);
+        return;
+      }
+      pendingWrites.add(frame);
+      try {
+        socket.write(frame, (error?: Error | null) => {
+          pendingWrites.delete(frame);
+          frame.fill(0);
+          if (error !== undefined && error !== null) {
+            fail(new ConnectivitySocks5Error(
+              "CONNECTIVITY_SOCKS5_WRITE_FAILED",
+              "Connectivity SOCKS5 request write failed",
+            ));
+          }
+        });
+      } catch {
+        pendingWrites.delete(frame);
+        frame.fill(0);
+        fail(new ConnectivitySocks5Error(
+          "CONNECTIVITY_SOCKS5_WRITE_FAILED",
+          "Connectivity SOCKS5 request write failed",
+        ));
+      }
+    };
+    const consume = (length: number): void => {
+      const remainder = Buffer.from(buffered.subarray(length));
+      buffered.fill(0);
+      buffered = remainder;
+    };
+    const process = (): void => {
+      while (!settled) {
+        if (phase === "method-response") {
+          if (buffered.length < 2) return;
+          if (buffered[0] !== SOCKS_VERSION) {
+            fail(new ConnectivitySocks5Error(
+              "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+              "Connectivity SOCKS5 proxy returned an unsupported protocol version",
+            ));
+            return;
+          }
+          if (buffered[1] !== JWT_AUTHENTICATION_METHOD) {
+            fail(new ConnectivitySocks5Error(
+              "CONNECTIVITY_SOCKS5_AUTHENTICATION_REJECTED",
+              "Connectivity SOCKS5 proxy did not accept JWT authentication",
+            ));
+            return;
+          }
+          consume(2);
+          phase = "authentication-response";
+          send(authenticationRequest(config));
+          continue;
+        }
+
+        if (phase === "authentication-response") {
+          if (buffered.length < 2) return;
+          if (buffered[0] !== JWT_AUTHENTICATION_VERSION) {
+            fail(new ConnectivitySocks5Error(
+              "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+              "Connectivity SOCKS5 proxy returned an unsupported authentication version",
+            ));
+            return;
+          }
+          if (buffered[1] !== 0x00) {
+            fail(new ConnectivitySocks5Error(
+              "CONNECTIVITY_SOCKS5_AUTHENTICATION_REJECTED",
+              "Connectivity SOCKS5 proxy rejected authentication",
+            ));
+            return;
+          }
+          consume(2);
+          phase = "connect-response";
+          send(connectRequest(config));
+          continue;
+        }
+
+        if (buffered.length < 4) return;
+        if (buffered[0] !== SOCKS_VERSION || buffered[2] !== 0x00) {
+          fail(new ConnectivitySocks5Error(
+            "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+            "Connectivity SOCKS5 proxy returned a malformed CONNECT response",
+          ));
+          return;
+        }
+        const replyCode = buffered[1]!;
+        if (replyCode !== 0x00) {
+          fail(new ConnectivitySocks5Error(
+            "CONNECTIVITY_SOCKS5_CONNECT_REJECTED",
+            "Connectivity SOCKS5 proxy rejected the target connection",
+            replyCode,
+          ));
+          return;
+        }
+        const addressType = buffered[3]!;
+        if (addressType === IPV4_ADDRESS) {
+          if (buffered.length < 10) return;
+          succeed(10);
+          return;
+        }
+        if (addressType === DOMAIN_ADDRESS) {
+          if (buffered.length < 5) return;
+          const domainLength = buffered[4]!;
+          if (domainLength === 0) {
+            fail(new ConnectivitySocks5Error(
+              "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+              "Connectivity SOCKS5 proxy returned an empty bound domain",
+            ));
+            return;
+          }
+          const responseLength = 7 + domainLength;
+          if (buffered.length < responseLength) return;
+          succeed(responseLength);
+          return;
+        }
+        fail(new ConnectivitySocks5Error(
+          "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+          "Connectivity SOCKS5 proxy returned an unsupported address type",
+        ));
+        return;
+      }
+    };
+    function onData(chunk: unknown): void {
+      if (settled) return;
+      if (!Buffer.isBuffer(chunk)) {
+        fail(new ConnectivitySocks5Error(
+          "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+          "Connectivity SOCKS5 proxy returned a non-binary response",
+        ));
+        return;
+      }
+      if (chunk.length > config.maxBufferedBytes - buffered.length) {
+        fail(new ConnectivitySocks5Error(
+          "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+          "Connectivity SOCKS5 response exceeded the configured byte bound",
+        ));
+        return;
+      }
+      const next = Buffer.concat([buffered, chunk], buffered.length + chunk.length);
+      buffered.fill(0);
+      buffered = next;
+      process();
+    }
+    function onError(): void {
+      fail(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_CONNECTION_CLOSED",
+        "Connectivity SOCKS5 connection failed during setup",
+      ));
+    }
+    function onEnd(): void {
+      fail(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_CONNECTION_CLOSED",
+        "Connectivity SOCKS5 connection ended during setup",
+      ));
+    }
+    function onClose(): void {
+      fail(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_CONNECTION_CLOSED",
+        "Connectivity SOCKS5 connection closed during setup",
+      ));
+    }
+    function onAbort(): void {
+      fail(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_ABORTED",
+        "Connectivity SOCKS5 setup was aborted",
+      ));
+    }
+
+    try {
+      socket.on("data", onData);
+      socket.on("error", onError);
+      socket.on("end", onEnd);
+      socket.on("close", onClose);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    } catch {
+      fail(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+        "Connectivity SOCKS5 lifecycle listeners could not be installed",
+      ));
+      return;
+    }
+    if (signalAborted(signal)) {
+      onAbort();
+      return;
+    }
+    try {
+      const handle = timers.set(() => fail(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_TIMEOUT",
+        "Connectivity SOCKS5 handshake timed out",
+      )), config.timeoutMs);
+      timer = handle;
+      if (settled) {
+        timer = NO_TIMER;
+        try { timers.clear(handle); } catch { /* best effort */ }
+        return;
+      }
+    } catch {
+      fail(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+        "Connectivity SOCKS5 timer scheduler failed",
+      ));
+      return;
+    }
+    send(Buffer.from([SOCKS_VERSION, 0x01, JWT_AUTHENTICATION_METHOD]));
+  });
+}
+
+function systemConnectProxy(
+  options: ConnectivitySocks5ProxyConnectOptions,
+): Promise<ConnectivitySocks5Socket> {
+  if (options.signal?.aborted === true) {
+    return Promise.reject(new ConnectivitySocks5Error(
+      "CONNECTIVITY_SOCKS5_ABORTED",
+      "Connectivity SOCKS5 setup was aborted",
+    ));
+  }
+  let socket: Socket;
+  try {
+    socket = createConnection({
+      host: options.proxyHost,
+      port: options.proxyPort,
+    });
+    socket.setNoDelay(true);
+  } catch {
+    return Promise.reject(new ConnectivitySocks5Error(
+      "CONNECTIVITY_SOCKS5_CONNECT_FAILED",
+      "Connectivity SOCKS5 proxy connection could not be started",
+    ));
+  }
+  const timers = schedulerFunctions(options.scheduler);
+  return new Promise<ConnectivitySocks5Socket>((resolve, reject) => {
+    let settled = false;
+    let timer: ConnectivitySocks5TimerHandle | typeof NO_TIMER = NO_TIMER;
+    const cleanup = (): void => {
+      socket.removeListener("connect", onConnect);
+      socket.removeListener("error", onError);
+      socket.removeListener("close", onClose);
+      options.signal?.removeEventListener("abort", onAbort);
+      if (timer !== NO_TIMER) {
+        const handle = timer;
+        timer = NO_TIMER;
+        try { timers.clear(handle); } catch { /* best effort */ }
+      }
+    };
+    const settle = (error?: ConnectivitySocks5Error): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error === undefined) resolve(socket);
+      else {
+        socket.destroy();
+        reject(error);
+      }
+    };
+    function onConnect(): void { settle(); }
+    function onError(): void {
+      settle(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_CONNECT_FAILED",
+        "Connectivity SOCKS5 proxy connection failed",
+      ));
+    }
+    function onClose(): void {
+      settle(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_CONNECT_FAILED",
+        "Connectivity SOCKS5 proxy connection closed before negotiation",
+      ));
+    }
+    function onAbort(): void {
+      settle(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_ABORTED",
+        "Connectivity SOCKS5 setup was aborted",
+      ));
+    }
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    if (options.signal?.aborted === true) {
+      onAbort();
+      return;
+    }
+    try {
+      const handle = timers.set(() => settle(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_CONNECT_TIMEOUT",
+        "Connectivity SOCKS5 proxy connection timed out",
+      )), options.timeoutMs);
+      timer = handle;
+      if (settled) {
+        timer = NO_TIMER;
+        try { timers.clear(handle); } catch { /* best effort */ }
+      }
+    } catch {
+      settle(new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_CONNECT_FAILED",
+        "Connectivity SOCKS5 connect timer scheduler failed",
+      ));
+    }
+  });
+}
+
+/** Validate, connect to the explicit SOCKS5 endpoint, and negotiate the tunnel. */
+export async function connectConnectivitySocks5Tunnel(
+  input: ConnectivitySocks5ConfigInput | AdmittedConnectivitySocks5Config,
+  signal?: AbortSignal,
+  dependencies: ConnectivitySocks5ConnectionDependencies = {},
+): Promise<EstablishedConnectivitySocks5Tunnel> {
+  const config = ADMITTED_CONFIGS.has(input as object)
+    ? input as AdmittedConnectivitySocks5Config
+    : admitConnectivitySocks5Config(input as ConnectivitySocks5ConfigInput);
+  assertAdmittedConnectivitySocks5Config(config);
+  if (
+    typeof dependencies !== "object" ||
+    dependencies === null ||
+    Array.isArray(dependencies)
+  ) {
+    throw new TypeError("Connectivity SOCKS5 connection dependencies must be an object");
+  }
+  const scheduler = dependencies.scheduler ?? SYSTEM_TIMER_SCHEDULER;
+  schedulerFunctions(scheduler);
+  const connector = dependencies.connect ?? systemConnectProxy;
+  if (typeof connector !== "function") {
+    throw new TypeError("Connectivity SOCKS5 proxy connector must be a function");
+  }
+  if (signalAborted(signal)) {
+    throw new ConnectivitySocks5Error(
+      "CONNECTIVITY_SOCKS5_ABORTED",
+      "Connectivity SOCKS5 setup was aborted",
+    );
+  }
+  let socket: ConnectivitySocks5Socket | undefined;
+  try {
+    socket = await Reflect.apply(connector, undefined, [Object.freeze({
+      proxyHost: config.proxyHost,
+      proxyPort: config.proxyPort,
+      timeoutMs: config.timeoutMs,
+      signal,
+      scheduler,
+    } satisfies ConnectivitySocks5ProxyConnectOptions)]) as ConnectivitySocks5Socket;
+    validateSocket(socket);
+  } catch (error) {
+    try { socket?.destroy(); } catch { /* connector failure remains authoritative */ }
+    if (error instanceof ConnectivitySocks5Error) throw error;
+    if (signal?.aborted === true) {
+      throw new ConnectivitySocks5Error(
+        "CONNECTIVITY_SOCKS5_ABORTED",
+        "Connectivity SOCKS5 setup was aborted",
+      );
+    }
+    throw new ConnectivitySocks5Error(
+      "CONNECTIVITY_SOCKS5_CONNECT_FAILED",
+      "Connectivity SOCKS5 proxy connector failed",
+    );
+  }
+  if (signal?.aborted === true) {
+    try { socket.destroy(); } catch { /* best effort */ }
+    throw new ConnectivitySocks5Error(
+      "CONNECTIVITY_SOCKS5_ABORTED",
+      "Connectivity SOCKS5 setup was aborted",
+    );
+  }
+  return establishConnectivitySocks5Tunnel(
+    socket,
+    config,
+    signal,
+    scheduler,
+  );
+}

--- a/test/compatibility-owner-route.test.ts
+++ b/test/compatibility-owner-route.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  planCompatibilityOwnerRoute,
+} from "../src/compat/compatibility-owner-route.js";
+import {
+  Client,
+  bindClientDestinationOwnerFactory,
+} from "../src/compat/node-rfc-client.js";
+import {
+  Pool,
+  bindPoolDestinationOwnerFactory,
+} from "../src/compat/node-rfc-pool.js";
+import type {
+  DirectCompatibilityOwnerFactoryContext,
+} from "../src/compat/direct-owner-factory.js";
+
+const ROUTE = "/H/router.fixture.invalid/S/3299/H/";
+const PARAMETERS = Object.freeze({
+  ashost: "application.fixture.invalid",
+  sysnr: "00",
+  client: "001",
+  user: "fixture-user",
+  passwd: "fixture-pw",
+  lang: "EN",
+  saprouter: ROUTE,
+});
+
+test("composes a routed physical-session factory only after strict direct admission", () => {
+  const planned = planCompatibilityOwnerRoute(PARAMETERS);
+
+  assert.equal(planned.kind, "direct");
+  assert.deepEqual(planned.connection, {
+    host: "application.fixture.invalid",
+    applicationServerHost: "application.fixture.invalid",
+    port: 3_300,
+    applicationServerService: "sapdp00",
+    client: "001",
+    user: "fixture-user",
+    password: "fixture-pw",
+    language: "E",
+    sysnr: "00",
+    cpicStreaming: "disabled",
+  });
+  assert.equal(typeof planned.sessionFactory?.open, "function");
+  assert.equal(Object.isFrozen(planned.sessionFactory), true);
+
+  assert.throws(
+    () => planCompatibilityOwnerRoute({
+      ...PARAMETERS,
+      saprouter: "/H/router.fixture.invalid/S/3299",
+    }),
+    /saprouter must be a valid SAProuter route prefix/u,
+  );
+});
+
+test("composes Connectivity SOCKS5 and refuses legacy RFC proxy before owner I/O", async () => {
+  const socks = planCompatibilityOwnerRoute({
+    ...PARAMETERS,
+    saprouter: undefined,
+    gwhost: "virtual-gateway.invalid",
+    connectivity_socks5_proxy_host: "proxy.fixture.invalid",
+    connectivity_socks5_proxy_port: 20_004,
+    connectivity_socks5_access_token: ["connectivity", "token", "fixture"].join("-"),
+  });
+  assert.equal(socks.kind, "direct");
+  assert.equal(socks.connection.host, "virtual-gateway.invalid");
+  assert.equal(typeof socks.sessionFactory?.open, "function");
+
+  let ownerCreations = 0;
+  const restoreClient = bindClientDestinationOwnerFactory({
+    create() {
+      ownerCreations += 1;
+      throw new Error("owner must not be created");
+    },
+  });
+  try {
+    await assert.rejects(
+      new Client({
+        ...PARAMETERS,
+        saprouter: undefined,
+        connectivity_proxy_host: "rfc-proxy.fixture.invalid",
+        connectivity_proxy_port: 20_001,
+      }).open() as Promise<Client>,
+      /Connectivity routes are not implemented/u,
+    );
+  } finally {
+    restoreClient();
+  }
+  assert.equal(ownerCreations, 0);
+});
+
+test("Client and Pool transfer the routed session factory to their destination owner", async () => {
+  const clientContexts: DirectCompatibilityOwnerFactoryContext[] = [];
+  const poolContexts: DirectCompatibilityOwnerFactoryContext[] = [];
+  const clientStop = new Error("client owner creation stopped before I/O");
+  const poolStop = new Error("pool owner creation stopped before I/O");
+  const restoreClient = bindClientDestinationOwnerFactory({
+    create(context) {
+      clientContexts.push(context);
+      throw clientStop;
+    },
+  });
+  try {
+    await assert.rejects(
+      new Client(PARAMETERS).open() as Promise<Client>,
+      (error: unknown) => error === clientStop,
+    );
+  } finally {
+    restoreClient();
+  }
+
+  const restorePool = bindPoolDestinationOwnerFactory({
+    create(context) {
+      poolContexts.push(context);
+      throw poolStop;
+    },
+  });
+  try {
+    assert.throws(
+      () => new Pool({
+        connectionParameters: PARAMETERS,
+        poolOptions: { low: 0, high: 1 },
+      }).monitor(),
+      (error) => error === poolStop,
+    );
+  } finally {
+    restorePool();
+  }
+
+  for (const [context] of [clientContexts, poolContexts]) {
+    assert.equal(context?.connection.host, "application.fixture.invalid");
+    assert.equal(context?.connection.applicationServerHost, "application.fixture.invalid");
+    assert.equal(typeof context?.sessionFactory?.open, "function");
+    assert.equal(Object.isFrozen(context?.sessionFactory), true);
+  }
+});

--- a/test/connection-parameters.test.ts
+++ b/test/connection-parameters.test.ts
@@ -1,0 +1,345 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { inspect } from "node:util";
+
+import {
+  captureDirectConnectionParameters,
+  languageIsoToSap,
+  languageSapToIso,
+  normalizeDirectConnectionParameters,
+  snapshotDirectConnectionParameters,
+} from "../src/compat/connection-parameters.js";
+
+const recognizedDirectParameterKeys = [
+  "ashost", "ASHOST",
+  "gwhost", "GWHOST",
+  "gwserv", "GWSERV",
+  "port", "PORT",
+  "sysnr", "SYSNR",
+  "client", "CLIENT",
+  "user", "USER",
+  "passwd", "PASSWD",
+  "lang", "LANG",
+  "cpic_streaming", "CPIC_STREAMING",
+  "mshost", "MSHOST",
+  "wshost", "WSHOST",
+  "wsport", "WSPORT",
+  "saprouter", "SAPROUTER",
+  "connectivity_proxy_host", "CONNECTIVITY_PROXY_HOST",
+  "connectivity_proxy_port", "CONNECTIVITY_PROXY_PORT",
+  "connectivity_proxy_authentication", "CONNECTIVITY_PROXY_AUTHENTICATION",
+  "connectivity_subaccount", "CONNECTIVITY_SUBACCOUNT",
+  "connectivity_location_id", "CONNECTIVITY_LOCATION_ID",
+  "connectivity_socks5_proxy_host", "CONNECTIVITY_SOCKS5_PROXY_HOST",
+  "connectivity_socks5_proxy_port", "CONNECTIVITY_SOCKS5_PROXY_PORT",
+  "connectivity_socks5_access_token", "CONNECTIVITY_SOCKS5_ACCESS_TOKEN",
+  "connectivity_socks5_location_id", "CONNECTIVITY_SOCKS5_LOCATION_ID",
+  "business_user_token", "BUSINESS_USER_TOKEN",
+  "snc_mode", "SNC_MODE",
+] as const;
+
+test("keeps every captured route credential non-enumerable", () => {
+  const values = {
+    ashost: "sap.example.test",
+    client: "001",
+    user: "RFCUSER",
+    passwd: "password-fixture",
+    connectivity_proxy_authentication: "proxy-authorization-fixture",
+    connectivity_socks5_access_token: "connectivity-token-fixture",
+    business_user_token: "business-token-fixture",
+  };
+  const snapshot = snapshotDirectConnectionParameters(values);
+  for (const [key, secret] of [
+    ["passwd", values.passwd],
+    ["connectivity_proxy_authentication", values.connectivity_proxy_authentication],
+    ["connectivity_socks5_access_token", values.connectivity_socks5_access_token],
+    ["business_user_token", values.business_user_token],
+  ] as const) {
+    assertHiddenPassword(snapshot, key, secret);
+  }
+});
+
+function assertHiddenPassword(
+  value: Readonly<Record<string, unknown>>,
+  key: string,
+  password: string,
+): void {
+  assert.equal(value[key], password);
+  assert.deepEqual(Object.getOwnPropertyDescriptor(value, key), {
+    configurable: false,
+    enumerable: false,
+    value: password,
+    writable: false,
+  });
+  assert.equal(JSON.stringify(value).includes(password), false);
+  assert.equal(inspect(value).includes(password), false);
+}
+
+test("captures recognized parameters once without inspecting arbitrary keys", () => {
+  const source = {
+    ASHOST: "sap.example.test",
+    SYSNR: 1,
+    CLIENT: 7,
+    USER: "RFCUSER",
+    PASSWD: "secret",
+    LANG: "en-US",
+  };
+  Object.defineProperty(source, "unrelated", {
+    enumerable: true,
+    get(): never {
+      throw new Error("unrelated getter must not run");
+    },
+  });
+
+  const descriptorReads = new Map<PropertyKey, number>();
+  const input = new Proxy(source, {
+    get(): never {
+      throw new Error("capture must not execute proxy property access");
+    },
+    getOwnPropertyDescriptor(target, key) {
+      descriptorReads.set(key, (descriptorReads.get(key) ?? 0) + 1);
+      return Reflect.getOwnPropertyDescriptor(target, key);
+    },
+    ownKeys(): never {
+      throw new Error("capture must not enumerate caller-owned keys");
+    },
+  });
+
+  const captured = captureDirectConnectionParameters(input);
+  for (const key of recognizedDirectParameterKeys) {
+    assert.equal(
+      descriptorReads.get(key),
+      1,
+      `${key} must be inspected exactly once`,
+    );
+  }
+  assert.equal(descriptorReads.has("unrelated"), false);
+  assert.deepEqual(captured.connectionParameters, {
+    ASHOST: "sap.example.test",
+    SYSNR: 1,
+    CLIENT: 7,
+    USER: "RFCUSER",
+    LANG: "en-US",
+  });
+  assertHiddenPassword(captured.connectionParameters, "PASSWD", "secret");
+  assert.equal(captured.normalized.password, "secret");
+  assert.ok(Object.isFrozen(captured));
+  assert.ok(Object.isFrozen(captured.connectionParameters));
+  assert.ok(Object.isFrozen(captured.normalized));
+});
+
+test("rejects accessor-backed parameters without executing mutation side effects", () => {
+  const source: Record<string, unknown> = {
+    client: "001",
+    user: "RFCUSER",
+    passwd: "secret",
+  };
+  let getterCalls = 0;
+  Object.defineProperty(source, "ashost", {
+    enumerable: true,
+    get() {
+      getterCalls += 1;
+      source.user = "MUTATED";
+      return "sap.example.test";
+    },
+  });
+
+  assert.throws(
+    () => captureDirectConnectionParameters(source),
+    /ashost must be an own data property/,
+  );
+  assert.equal(getterCalls, 0);
+  assert.equal(source.user, "RFCUSER");
+});
+
+test("freezes a construction-time snapshot independently of later caller mutation", () => {
+  const source: Record<string, unknown> = {
+    ashost: "sap.example.test",
+    client: "001",
+    user: "RFCUSER",
+    passwd: "secret",
+  };
+  const captured = captureDirectConnectionParameters(source);
+
+  source.ashost = "changed.example.test";
+  source.user = "CHANGED";
+  source.passwd = ["changed", "secret"].join("-");
+
+  assert.deepEqual(captured.connectionParameters, {
+    ashost: "sap.example.test",
+    client: "001",
+    user: "RFCUSER",
+  });
+  assertHiddenPassword(captured.connectionParameters, "passwd", "secret");
+  assert.equal(captured.normalized.host, "sap.example.test");
+  assert.equal(captured.normalized.user, "RFCUSER");
+  assert.equal(captured.normalized.password, "secret");
+  assert.throws(
+    () => {
+      (captured.connectionParameters as Record<string, unknown>).user = "MUTATED";
+    },
+    TypeError,
+  );
+});
+
+test("normalizes lowercase and uppercase direct RFC parameters", () => {
+  assert.deepEqual(normalizeDirectConnectionParameters({
+    ASHOST: "sap.example.test",
+    SYSNR: 1,
+    CLIENT: 7,
+    USER: "RFCUSER",
+    PASSWD: "secret",
+    LANG: "en-US",
+  }), {
+    host: "sap.example.test",
+    applicationServerHost: "sap.example.test",
+    port: 3301,
+    applicationServerService: "sapdp01",
+    client: "007",
+    user: "RFCUSER",
+    password: "secret",
+    language: "E",
+    sysnr: "01",
+    cpicStreaming: "disabled",
+  });
+  assert.equal(languageIsoToSap("de"), "D");
+  assert.equal(languageSapToIso("D"), "DE");
+});
+
+test("converts archived SAP and ISO language identifiers bidirectionally", () => {
+  assert.equal(languageIsoToSap("AF"), "a");
+  assert.equal(languageSapToIso("a"), "AF");
+  assert.equal(languageIsoToSap("6N"), "둮");
+  assert.equal(languageSapToIso("둮"), "6N");
+  assert.equal(languageIsoToSap("Z9"), "&");
+  assert.equal(languageSapToIso("&"), "Z9");
+  assert.equal(languageIsoToSap("en-US"), "E");
+  assert.throws(
+    () => languageIsoToSap("ŠĐ"),
+    { message: "Language ISO code not found: ŠĐ" },
+  );
+  assert.throws(
+    () => languageSapToIso("Š"),
+    { message: "Language SAP code not found: Š" },
+  );
+  assert.throws(
+    () => languageSapToIso("__proto__"),
+    { message: "Language SAP code not found: __proto__" },
+  );
+});
+
+test("keeps the application server distinct from an explicit gateway endpoint", () => {
+  const normalized = normalizeDirectConnectionParameters({
+    ashost: "application.example.test",
+    gwhost: "gateway.example.test",
+    sysnr: "00",
+    gwserv: "43300",
+    client: "001",
+    user: "RFCUSER",
+    passwd: "secret",
+  });
+  assert.equal(normalized.host, "gateway.example.test");
+  assert.equal(normalized.applicationServerHost, "application.example.test");
+  assert.equal(normalized.port, 43300);
+  assert.equal(normalized.cpicStreaming, "disabled");
+  assert.deepEqual(
+    normalizeDirectConnectionParameters({
+      ASHOST: "application.example.test",
+      GWHOST: "gateway.example.test",
+      GWSERV: "sapgw00",
+      CLIENT: "001",
+      USER: "RFCUSER",
+      PASSWD: "secret",
+    }),
+    { ...normalized, port: 3300 },
+  );
+  assert.throws(
+    () =>
+      normalizeDirectConnectionParameters({
+        ashost: "application.example.test",
+        gwhost: "one.example.test",
+        GWHOST: "two.example.test",
+        client: "001",
+        user: "RFCUSER",
+        passwd: "secret",
+      }),
+    /conflicting gwhost and GWHOST values/,
+  );
+  for (const ashost of ["bad\nhost", "x".repeat(65)]) {
+    assert.throws(
+      () =>
+        normalizeDirectConnectionParameters({
+          ashost,
+          client: "001",
+          user: "RFCUSER",
+          passwd: "secret",
+        }),
+      /ashost must contain 1\.\.64 ASCII bytes/,
+    );
+  }
+  // The compatibility route selector gives ASHOST precedence over MSHOST.
+  // The direct normalizer therefore retains the selected direct route and
+  // ignores the lower-priority message-server fields.
+  const directWithLowerPriorityMessageRoute = normalizeDirectConnectionParameters({
+    mshost: "message.example.test",
+    ashost: "sap.example.test",
+    client: "001",
+    user: "RFCUSER",
+    passwd: "secret",
+  });
+  assert.equal(directWithLowerPriorityMessageRoute.host, "sap.example.test");
+  assert.equal(
+    directWithLowerPriorityMessageRoute.applicationServerHost,
+    "sap.example.test",
+  );
+  assert.throws(
+    () => normalizeDirectConnectionParameters({
+      ashost: "sap.example.test",
+      client: "001",
+      user: "RFCUSER",
+      passwd: "secret",
+      lang: "not-a-language",
+    }),
+    /Language ISO code not found/,
+  );
+  assert.equal(
+    normalizeDirectConnectionParameters({
+      ashost: "sap.example.test",
+      client: "001",
+      user: "RFCUSER",
+      passwd: "secret",
+      cpic_streaming: "enabled",
+    }).cpicStreaming,
+    "enabled",
+  );
+  assert.throws(
+    () => normalizeDirectConnectionParameters({
+      ashost: "sap.example.test",
+      client: "001",
+      user: "RFCUSER",
+      passwd: "secret",
+      cpic_streaming: true,
+    }),
+    /cpic_streaming must be disabled or enabled/,
+  );
+});
+
+test("preserves direct validation order while exposing route-only normalization", () => {
+  assert.throws(
+    () => normalizeDirectConnectionParameters({
+      ashost: "application.example.test",
+      gwserv: "invalid-service",
+      client: "invalid-client",
+      lang: "invalid-language",
+    }),
+    /gwserv must be a TCP port or sapgwNN service name/u,
+  );
+  assert.throws(
+    () => normalizeDirectConnectionParameters({
+      ashost: "application.example.test",
+      client: "001",
+      lang: "invalid-language",
+    }),
+    /user must be a non-empty string or number/u,
+  );
+});

--- a/test/connection-parameters.test.ts
+++ b/test/connection-parameters.test.ts
@@ -45,34 +45,53 @@ test("keeps every captured route credential non-enumerable", () => {
     user: "RFCUSER",
     passwd: "password-fixture",
     connectivity_proxy_authentication: "proxy-authorization-fixture",
+    connectivity_location_id: "proxy-location-fixture",
     connectivity_socks5_access_token: "connectivity-token-fixture",
+    connectivity_socks5_location_id: "socks-location-fixture",
     business_user_token: "business-token-fixture",
   };
   const snapshot = snapshotDirectConnectionParameters(values);
   for (const [key, secret] of [
     ["passwd", values.passwd],
     ["connectivity_proxy_authentication", values.connectivity_proxy_authentication],
+    ["connectivity_location_id", values.connectivity_location_id],
     ["connectivity_socks5_access_token", values.connectivity_socks5_access_token],
+    ["connectivity_socks5_location_id", values.connectivity_socks5_location_id],
     ["business_user_token", values.business_user_token],
   ] as const) {
-    assertHiddenPassword(snapshot, key, secret);
+    assertHiddenCredential(snapshot, key, secret);
   }
+
+  const uppercaseSnapshot = snapshotDirectConnectionParameters({
+    CONNECTIVITY_LOCATION_ID: "uppercase-proxy-location-fixture",
+    CONNECTIVITY_SOCKS5_LOCATION_ID: "uppercase-socks-location-fixture",
+  });
+  assertHiddenCredential(
+    uppercaseSnapshot,
+    "CONNECTIVITY_LOCATION_ID",
+    "uppercase-proxy-location-fixture",
+  );
+  assertHiddenCredential(
+    uppercaseSnapshot,
+    "CONNECTIVITY_SOCKS5_LOCATION_ID",
+    "uppercase-socks-location-fixture",
+  );
 });
 
-function assertHiddenPassword(
+function assertHiddenCredential(
   value: Readonly<Record<string, unknown>>,
   key: string,
-  password: string,
+  credential: string,
 ): void {
-  assert.equal(value[key], password);
+  assert.equal(value[key], credential);
   assert.deepEqual(Object.getOwnPropertyDescriptor(value, key), {
     configurable: false,
     enumerable: false,
-    value: password,
+    value: credential,
     writable: false,
   });
-  assert.equal(JSON.stringify(value).includes(password), false);
-  assert.equal(inspect(value).includes(password), false);
+  assert.equal(JSON.stringify(value).includes(credential), false);
+  assert.equal(inspect(value).includes(credential), false);
 }
 
 test("captures recognized parameters once without inspecting arbitrary keys", () => {
@@ -121,7 +140,7 @@ test("captures recognized parameters once without inspecting arbitrary keys", ()
     USER: "RFCUSER",
     LANG: "en-US",
   });
-  assertHiddenPassword(captured.connectionParameters, "PASSWD", "secret");
+  assertHiddenCredential(captured.connectionParameters, "PASSWD", "secret");
   assert.equal(captured.normalized.password, "secret");
   assert.ok(Object.isFrozen(captured));
   assert.ok(Object.isFrozen(captured.connectionParameters));
@@ -170,7 +189,7 @@ test("freezes a construction-time snapshot independently of later caller mutatio
     client: "001",
     user: "RFCUSER",
   });
-  assertHiddenPassword(captured.connectionParameters, "passwd", "secret");
+  assertHiddenCredential(captured.connectionParameters, "passwd", "secret");
   assert.equal(captured.normalized.host, "sap.example.test");
   assert.equal(captured.normalized.user, "RFCUSER");
   assert.equal(captured.normalized.password, "secret");

--- a/test/connection-route.test.ts
+++ b/test/connection-route.test.ts
@@ -1,0 +1,539 @@
+import assert from "node:assert/strict";
+import { inspect, types as nodeUtilTypes } from "node:util";
+import test from "node:test";
+
+import { normalizeDirectConnectionParameters } from "../src/compat/connection-parameters.js";
+import {
+  assertConnectionRouteCapabilities,
+  MissingConnectionProviderCapabilitiesError,
+  planConnectionRoute,
+  type ConnectionProviderCapability,
+} from "../src/compat/connection-route.js";
+
+const namedUser = Object.freeze({
+  client: "001",
+  user: "RFCUSER",
+  passwd: ["named-user", "secret"].join("-"),
+});
+
+test("plans direct RFC with the existing normalization contract", () => {
+  const input = {
+    ASHOST: "application.example.test",
+    GWHOST: "gateway.example.test",
+    GWSERV: "sapgw01",
+    SYSNR: 1,
+    CLIENT: 7,
+    USER: "RFCUSER",
+    PASSWD: ["named-user", "secret"].join("-"),
+    LANG: "en-US",
+    CPIC_STREAMING: "enabled",
+  };
+  const legacy = normalizeDirectConnectionParameters(input);
+  const plan = planConnectionRoute(input);
+
+  assert.deepEqual(plan.route, {
+    kind: "direct",
+    host: legacy.host,
+    applicationServerHost: legacy.applicationServerHost,
+    port: legacy.port,
+    applicationServerService: legacy.applicationServerService,
+    sysnr: legacy.sysnr,
+    cpicStreaming: legacy.cpicStreaming,
+  });
+  assert.deepEqual(plan.logon, {
+    client: legacy.client,
+    language: legacy.language,
+  });
+  assert.equal(plan.authentication.kind, "named-user");
+  assert.equal(plan.authentication.user, legacy.user);
+  assert.equal(plan.authentication.password, legacy.password);
+  assert.deepEqual(plan.requiredProviderCapabilities, [
+    "direct-rfc-transport",
+    "named-user-authentication",
+  ]);
+  assert.ok(Object.isFrozen(plan));
+  assert.ok(Object.isFrozen(plan.route));
+  assert.ok(Object.isFrozen(plan.logon));
+  assert.ok(Object.isFrozen(plan.authentication));
+  assert.ok(Object.isFrozen(plan.requiredProviderCapabilities));
+});
+
+test("uses the pinned direct then message-server then WebSocket precedence", () => {
+  const direct = planConnectionRoute({
+    ...namedUser,
+    ashost: "direct.example.test",
+    mshost: "message.example.test",
+    msserv: "sapmsQAS",
+    sysid: "QAS",
+    group: "PUBLIC",
+    wshost: "websocket.example.test",
+    wsport: 443,
+  });
+  assert.equal(direct.route.kind, "direct");
+
+  const messageServer = planConnectionRoute({
+    ...namedUser,
+    mshost: "message.example.test",
+    sysid: "QAS",
+    group: "PUBLIC",
+    wshost: "websocket.example.test",
+    wsport: 443,
+  });
+  assert.deepEqual(messageServer.route, {
+    kind: "message-server",
+    messageServerHost: "message.example.test",
+    systemId: "QAS",
+    group: "PUBLIC",
+  });
+});
+
+test("plans all unchanged message-server fields without claiming a provider", () => {
+  const plan = planConnectionRoute({
+    ...namedUser,
+    mshost: "message.example.test",
+    msserv: "sapmsQAS",
+    sysid: "QAS",
+    group: "RFC_GROUP",
+    lang: "de",
+  });
+
+  assert.deepEqual(plan.route, {
+    kind: "message-server",
+    messageServerHost: "message.example.test",
+    messageServerService: "sapmsQAS",
+    systemId: "QAS",
+    group: "RFC_GROUP",
+  });
+  assert.deepEqual(plan.logon, { client: "001", language: "D" });
+  assert.deepEqual(plan.requiredProviderCapabilities, [
+    "message-server-rfc-transport",
+    "named-user-authentication",
+  ]);
+  assert.throws(
+    () => assertConnectionRouteCapabilities(plan, new Set()),
+    (error: unknown) => {
+      assert.ok(error instanceof MissingConnectionProviderCapabilitiesError);
+      assert.equal(error.code, "ERR_OPEN_RFC_CONNECTION_PROVIDER_CAPABILITY");
+      assert.deepEqual(error.missingCapabilities, [
+        "message-server-rfc-transport",
+        "named-user-authentication",
+      ]);
+      return true;
+    },
+  );
+});
+
+test("accepts r3name directly and gives it precedence over sysid", () => {
+  const preferred = planConnectionRoute({
+    ...namedUser,
+    mshost: "message.example.test",
+    r3name: "QAS",
+    sysid: "IGN",
+    group: "PUBLIC",
+  });
+  assert.equal(preferred.route.kind, "message-server");
+  if (preferred.route.kind !== "message-server") assert.fail("message route");
+  assert.equal(preferred.route.systemId, "QAS");
+
+  const fallback = planConnectionRoute({
+    ...namedUser,
+    mshost: "message.example.test",
+    sysid: "QAS",
+    group: "PUBLIC",
+  });
+  assert.equal(fallback.route.kind, "message-server");
+  if (fallback.route.kind !== "message-server") assert.fail("message route");
+  assert.equal(fallback.route.systemId, "QAS");
+});
+
+test("plans WebSocket host and optional numeric port as a distinct transport", () => {
+  const withPort = planConnectionRoute({
+    ...namedUser,
+    wshost: "websocket.example.test",
+    wsport: "443",
+  });
+  assert.deepEqual(withPort.route, {
+    kind: "websocket",
+    host: "websocket.example.test",
+    port: 443,
+  });
+  assert.deepEqual(withPort.requiredProviderCapabilities, [
+    "websocket-rfc-transport",
+    "named-user-authentication",
+  ]);
+
+  const withoutPort = planConnectionRoute({
+    ...namedUser,
+    wshost: "websocket.example.test",
+  });
+  assert.deepEqual(withoutPort.route, {
+    kind: "websocket",
+    host: "websocket.example.test",
+  });
+});
+
+test("keeps a validated SAProuter route string opaque and provider-gated", () => {
+  const routeString = "/H/router.example.test/S/3299/W/router-secret/H/";
+  const plan = planConnectionRoute({
+    ...namedUser,
+    ashost: "application.example.test",
+    gwhost: "gateway.example.test",
+    gwserv: "sapgw01",
+    sysnr: "01",
+    saprouter: routeString,
+  });
+
+  assert.equal(plan.sapRouter?.routeString, routeString);
+  assert.equal(plan.route.kind, "direct");
+  if (plan.route.kind !== "direct") assert.fail("expected direct route");
+  assert.equal(plan.route.host, "gateway.example.test");
+  assert.equal(plan.route.port, 3_301);
+  assert.equal(plan.route.applicationServerHost, "application.example.test");
+  assert.deepEqual(plan.requiredProviderCapabilities, [
+    "direct-rfc-transport",
+    "named-user-authentication",
+    "saprouter-routing",
+  ]);
+  assert.doesNotMatch(inspect(plan, { depth: null }), /router-secret/u);
+  assert.doesNotMatch(JSON.stringify(plan), /router-secret/u);
+
+  for (const invalid of [
+    "router.example.test",
+    "/h/router.example.test/H/application.example.test",
+    "/H/x/H/application.example.test",
+    "/H/router.example.test/S/",
+    "/H/router.example.test/W/secret",
+    "/H/router.example.test/X/value/H/application.example.test",
+    "/H/router.example.test/P/legacy-secret/H/",
+    "/H/router.example.test",
+    "/H/router.example.test/H/application.example.test/S/sapgw01",
+  ]) {
+    assert.throws(
+      () => planConnectionRoute({
+        ...namedUser,
+        ashost: "application.example.test",
+        saprouter: invalid,
+      }),
+      /saprouter must be a valid SAProuter route prefix/u,
+    );
+  }
+});
+
+test("rejects SAProuter with a selected WebSocket route", () => {
+  assert.throws(
+    () => planConnectionRoute({
+      ...namedUser,
+      wshost: "websocket.example.test",
+      saprouter: "/H/router.example.test/H/",
+    }),
+    /saprouter cannot be combined with WebSocket RFC/u,
+  );
+});
+
+test("requires a distinct capability for message-server over SAProuter", () => {
+  const plan = planConnectionRoute({
+    ...namedUser,
+    mshost: "message.example.test",
+    msserv: "3600",
+    sysid: "QAS",
+    group: "PUBLIC",
+    saprouter: "/H/router.example.test/S/3299/H/",
+  });
+  assert.deepEqual(plan.requiredProviderCapabilities, [
+    "message-server-rfc-transport",
+    "named-user-authentication",
+    "saprouter-routing",
+    "message-server-saprouter-routing",
+  ]);
+  assert.throws(
+    () => assertConnectionRouteCapabilities(plan, new Set([
+      "message-server-rfc-transport",
+      "named-user-authentication",
+      "saprouter-routing",
+    ])),
+    (error: unknown) =>
+      error instanceof MissingConnectionProviderCapabilitiesError &&
+      error.missingCapabilities.length === 1 &&
+      error.missingCapabilities[0] === "message-server-saprouter-routing",
+  );
+});
+
+test("plans Connectivity proxy authorization, tenant, and location fields immutably", () => {
+  const source: Record<string, unknown> = {
+    ...namedUser,
+    ashost: "virtual-application.test",
+    connectivity_proxy_host: "connectivity-proxy.internal",
+    connectivity_proxy_port: "20001",
+    connectivity_proxy_authentication: "Bearer proxy-secret",
+    connectivity_subaccount: "tenant-a",
+    connectivity_location_id: "location-a",
+  };
+  const plan = planConnectionRoute(source);
+  source.connectivity_proxy_authentication = "Bearer changed";
+  source.connectivity_subaccount = "tenant-b";
+
+  assert.equal(plan.connectivityProxy?.host, "connectivity-proxy.internal");
+  assert.equal(plan.connectivityProxy?.port, 20001);
+  assert.equal(plan.connectivityProxy?.authorization, "Bearer proxy-secret");
+  assert.equal(plan.connectivityProxy?.subaccount, "tenant-a");
+  assert.equal(plan.connectivityProxy?.locationId, "location-a");
+  assert.ok(Object.isFrozen(plan.connectivityProxy));
+  assert.deepEqual(plan.requiredProviderCapabilities, [
+    "direct-rfc-transport",
+    "named-user-authentication",
+    "connectivity-rfc-proxy",
+    "connectivity-proxy-authorization",
+  ]);
+  assert.doesNotMatch(inspect(plan, { depth: null }), /proxy-secret/u);
+  assert.doesNotMatch(JSON.stringify(plan), /proxy-secret/u);
+});
+
+test("plans a distinct Connectivity SOCKS5 route and redacts its credentials", () => {
+  const accessToken = ["connectivity", "access", "fixture"].join("-");
+  const source: Record<string, unknown> = {
+    ...namedUser,
+    ashost: "application.internal",
+    gwhost: "virtual-gateway.invalid",
+    gwserv: "3300",
+    connectivity_socks5_proxy_host: "connectivity-proxy.internal",
+    connectivity_socks5_proxy_port: "20004",
+    connectivity_socks5_access_token: accessToken,
+    connectivity_socks5_location_id: "location-a",
+  };
+  const plan = planConnectionRoute(source);
+  source.connectivity_socks5_access_token = "changed";
+
+  assert.deepEqual(plan.connectivitySocks5, {
+    host: "connectivity-proxy.internal",
+    port: 20_004,
+    accessToken,
+    locationId: "location-a",
+  });
+  assert.ok(Object.isFrozen(plan.connectivitySocks5));
+  assert.deepEqual(plan.requiredProviderCapabilities, [
+    "direct-rfc-transport",
+    "named-user-authentication",
+    "connectivity-socks5-tcp",
+  ]);
+  assert.doesNotMatch(inspect(plan, { depth: null }), /connectivity-access-fixture|location-a/u);
+  assert.doesNotMatch(JSON.stringify(plan), /connectivity-access-fixture|location-a/u);
+});
+
+test("fails closed for partial, prefixed, or combined Connectivity SOCKS5 routes", () => {
+  const complete = {
+    connectivity_socks5_proxy_host: "connectivity-proxy.internal",
+    connectivity_socks5_proxy_port: 20_004,
+    connectivity_socks5_access_token: ["connectivity", "access", "fixture"].join("-"),
+  };
+  const direct = { ...namedUser, ashost: "application.internal" };
+  const cases: ReadonlyArray<readonly [Record<string, unknown>, RegExp]> = [
+    [{ ...direct, connectivity_socks5_proxy_host: "proxy.internal" }, /must be supplied together/u],
+    [{ ...direct, connectivity_socks5_proxy_port: 20_004 }, /must be supplied together/u],
+    [{ ...direct, connectivity_socks5_access_token: "token" }, /must be supplied together/u],
+    [{ ...direct, connectivity_socks5_location_id: "location-a" }, /requires the complete Connectivity SOCKS5 route/u],
+    [{ ...direct, ...complete, connectivity_socks5_access_token: "Bearer token" }, /raw token without a Bearer prefix/u],
+    [{
+      ...direct,
+      ...complete,
+      connectivity_proxy_host: "rfc-proxy.internal",
+      connectivity_proxy_port: 20_001,
+    }, /RFC proxy and Connectivity SOCKS5 routes cannot be combined/u],
+    [{ ...direct, ...complete, saprouter: "/H/router.example.test/H/" }, /cannot be combined with SAProuter/u],
+    [{
+      ...namedUser,
+      mshost: "message.internal",
+      sysid: "A4H",
+      group: "PUBLIC",
+      ...complete,
+    }, /only for a direct ashost route/u],
+    [{ ...namedUser, wshost: "websocket.internal", ...complete }, /only for a direct ashost route/u],
+  ];
+
+  for (const [input, expected] of cases) {
+    assert.throws(() => planConnectionRoute(input), expected);
+  }
+});
+
+test("plans business-user principal propagation without named-user credentials", () => {
+  const token = ["business-user-token", "secret"].join("-");
+  const plan = planConnectionRoute({
+    ashost: "virtual-application.test",
+    client: "001",
+    business_user_token: token,
+    connectivity_proxy_host: "connectivity-proxy.internal",
+    connectivity_proxy_port: 20001,
+    connectivity_proxy_authentication: "Bearer proxy-secret",
+    connectivity_subaccount: "tenant-a",
+  });
+
+  assert.equal(plan.authentication.kind, "principal-propagation");
+  assert.equal(plan.authentication.businessUserToken, token);
+  assert.deepEqual(plan.requiredProviderCapabilities, [
+    "direct-rfc-transport",
+    "principal-propagation",
+    "connectivity-rfc-proxy",
+    "connectivity-proxy-authorization",
+  ]);
+  assert.doesNotMatch(inspect(plan, { depth: null }), /business-user-token-secret|proxy-secret/u);
+  assert.doesNotMatch(JSON.stringify(plan), /business-user-token-secret|proxy-secret/u);
+});
+
+test("fails closed for conflicting, incomplete, or unsupported authentication and proxy inputs", () => {
+  const base = { ashost: "application.example.test", client: "001" };
+  const cases: ReadonlyArray<readonly [Record<string, unknown>, RegExp]> = [
+    [{ ...base, user: "RFCUSER" }, /user and passwd must be supplied together/u],
+    [{ ...base, passwd: "secret" }, /user and passwd must be supplied together/u],
+    [{ ...base, ...namedUser, business_user_token: "business-secret" }, /business_user_token cannot be combined with user or passwd/u],
+    [{ ...base, business_user_token: "business-secret" }, /business_user_token requires a Connectivity proxy route/u],
+    [{ ...base, ...namedUser, connectivity_proxy_host: "proxy.internal" }, /connectivity_proxy_host and connectivity_proxy_port must be supplied together/u],
+    [{ ...base, ...namedUser, connectivity_proxy_port: 20001 }, /connectivity_proxy_host and connectivity_proxy_port must be supplied together/u],
+    [{ ...base, ...namedUser, connectivity_subaccount: "tenant-a" }, /Connectivity proxy options require connectivity_proxy_host and connectivity_proxy_port/u],
+    [{ ...base, ...namedUser, connectivity_location_id: "location-a" }, /Connectivity proxy options require connectivity_proxy_host and connectivity_proxy_port/u],
+    [{ ...base, ...namedUser, connectivity_proxy_authentication: "Bearer proxy-secret" }, /Connectivity proxy options require connectivity_proxy_host and connectivity_proxy_port/u],
+  ];
+
+  for (const [input, expected] of cases) {
+    let error: unknown;
+    try {
+      planConnectionRoute(input);
+    } catch (caught) {
+      error = caught;
+    }
+    assert.ok(error instanceof Error);
+    assert.match(error.message, expected);
+    assert.doesNotMatch(error.message, /named-user-secret|business-secret|proxy-secret/u);
+  }
+});
+
+test("rejects unknown, inherited, accessor, proxy, symbol, and duplicate inputs before planning", () => {
+  assert.throws(
+    () => planConnectionRoute({ ...namedUser, ashost: "application.example.test", timeout: 10 }),
+    /unknown RFC connection parameter timeout/u,
+  );
+  assert.throws(
+    () => planConnectionRoute({
+      ...namedUser,
+      ashost: "application.example.test",
+      r3name: "QAS",
+    }),
+    /r3name requires a selected mshost route/u,
+  );
+  assert.throws(
+    () => planConnectionRoute({
+      ...namedUser,
+      ashost: "application.example.test",
+      connectivity_proxy_authorization: "Bearer secret",
+    }),
+    /unknown RFC connection parameter connectivity_proxy_authorization/u,
+  );
+
+  const inherited = Object.assign(
+    Object.create({ ashost: "inherited.example.test" }) as Record<string, unknown>,
+    namedUser,
+  );
+  assert.throws(
+    () => planConnectionRoute(inherited),
+    /RFC connection parameters must not have a custom prototype/u,
+  );
+
+  let getterCalls = 0;
+  const accessor: Record<string, unknown> = { ...namedUser };
+  Object.defineProperty(accessor, "ashost", {
+    enumerable: true,
+    get() {
+      getterCalls += 1;
+      return "application.example.test";
+    },
+  });
+  assert.throws(
+    () => planConnectionRoute(accessor),
+    /ashost must be an own data property/u,
+  );
+  assert.equal(getterCalls, 0);
+
+  let trapCalls = 0;
+  const proxied = new Proxy({
+    ...namedUser,
+    ashost: "application.example.test",
+  }, {
+    getPrototypeOf(target) {
+      trapCalls += 1;
+      return Reflect.getPrototypeOf(target);
+    },
+    ownKeys(target) {
+      trapCalls += 1;
+      return Reflect.ownKeys(target);
+    },
+  });
+  assert.equal(nodeUtilTypes.isProxy(proxied), true);
+  assert.throws(
+    () => planConnectionRoute(proxied),
+    /RFC connection parameters must not be a Proxy/u,
+  );
+  assert.equal(trapCalls, 0);
+
+  const withSymbol = {
+    ...namedUser,
+    ashost: "application.example.test",
+    [Symbol("hidden")]: "value",
+  };
+  assert.throws(
+    () => planConnectionRoute(withSymbol),
+    /RFC connection parameter keys must be strings/u,
+  );
+
+  assert.throws(
+    () => planConnectionRoute({
+      ...namedUser,
+      ashost: "application.example.test",
+      ASHOST: "application.example.test",
+    }),
+    /duplicate RFC connection parameter ashost/u,
+  );
+  assert.throws(
+    () => planConnectionRoute({
+      ...namedUser,
+      ashost: "one.example.test",
+      ASHOST: "two.example.test",
+    }),
+    /duplicate RFC connection parameter ashost/u,
+  );
+});
+
+test("rejects missing or malformed route-specific fields before provider selection", () => {
+  const cases: ReadonlyArray<readonly [Record<string, unknown>, RegExp]> = [
+    [{ ...namedUser }, /one of ashost, mshost, or wshost is required/u],
+    [{ ...namedUser, msserv: "sapmsQAS", sysid: "QAS", group: "PUBLIC" }, /msserv requires a selected mshost route/u],
+    [{ ...namedUser, mshost: "message.example.test", group: "PUBLIC" }, /sysid is required for a message-server route/u],
+    [{ ...namedUser, mshost: "message.example.test", sysid: "QAS" }, /group is required for a message-server route/u],
+    [{ ...namedUser, mshost: "message.example.test", sysid: "TOOLONG", group: "PUBLIC" }, /sysid must be a three-character SAP system ID/u],
+    [{ ...namedUser, wshost: "websocket.example.test", wsport: 0 }, /wsport must be an integer in 1\.\.65535/u],
+    [{ ...namedUser, wsport: 443 }, /wsport requires a selected wshost route/u],
+  ];
+  for (const [input, expected] of cases) {
+    assert.throws(() => planConnectionRoute(input), expected);
+  }
+});
+
+test("capability admission returns no transport and reveals no connection secrets", () => {
+  const plan = planConnectionRoute({
+    ...namedUser,
+    ashost: "application.example.test",
+  });
+  const all = new Set<ConnectionProviderCapability>(plan.requiredProviderCapabilities);
+  assert.doesNotThrow(() => assertConnectionRouteCapabilities(plan, all));
+  assert.equal("connect" in plan, false);
+  assert.equal("open" in plan, false);
+
+  const missingNamedUser = new Set<ConnectionProviderCapability>([
+    "direct-rfc-transport",
+  ]);
+  let error: unknown;
+  try {
+    assertConnectionRouteCapabilities(plan, missingNamedUser);
+  } catch (caught) {
+    error = caught;
+  }
+  assert.ok(error instanceof Error);
+  assert.doesNotMatch(inspect(error, { depth: null }), /named-user-secret/u);
+});

--- a/test/connectivity-socks5-ni.test.ts
+++ b/test/connectivity-socks5-ni.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import {
+  createConnection,
+  createServer,
+  type Server,
+  type Socket,
+} from "node:net";
+import test from "node:test";
+
+import { encodeNiFrame } from "../src/protocol/ni.js";
+import {
+  createConnectivitySocks5DirectCpicTransportFactory,
+} from "../src/transport/connectivity-socks5-ni.js";
+import type {
+  AdmittedConnectivitySocks5Config,
+  EstablishedConnectivitySocks5Tunnel,
+} from "../src/transport/connectivity-socks5-tunnel.js";
+
+const FIXTURE_ACCESS_TOKEN = ["header", "payload", "signature"].join(".");
+
+async function listen(): Promise<{ server: Server; port: number }> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("test server did not bind a TCP address");
+  }
+  return { server, port: address.port };
+}
+
+async function connect(port: number): Promise<Socket> {
+  const socket = createConnection({ host: "127.0.0.1", port });
+  await new Promise<void>((resolve, reject) => {
+    socket.once("connect", resolve);
+    socket.once("error", reject);
+  });
+  socket.pause();
+  return socket;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error === undefined ? resolve() : reject(error));
+  });
+}
+
+test("adopts an explicitly configured Connectivity SOCKS5 TCP tunnel for NI", async (t) => {
+  const { server, port } = await listen();
+  t.after(() => closeServer(server));
+  const initialData = encodeNiFrame(Buffer.from("first-target-frame"));
+  const calls: AdmittedConnectivitySocks5Config[] = [];
+  const factory = createConnectivitySocks5DirectCpicTransportFactory({
+    proxyHost: "connectivity-proxy.fixture.invalid",
+    proxyPort: 20_004,
+    accessToken: FIXTURE_ACCESS_TOKEN,
+    locationId: "berlin-1",
+    timeoutMs: 4_321,
+    maxBufferedBytes: 8_192,
+  }, {
+    async connectTunnel(config): Promise<EstablishedConnectivitySocks5Tunnel> {
+      calls.push(config);
+      return Object.freeze({
+        socket: await connect(port),
+        initialData,
+      });
+    },
+  });
+  const controller = new AbortController();
+
+  const transport = await factory({
+    host: "virtual-gateway.fixture.invalid",
+    port: 3_342,
+    connectTimeoutMs: 1_234,
+    maxPayloadLength: 4_096,
+    noDelay: false,
+    family: 4,
+  }, controller.signal);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.proxyHost, "connectivity-proxy.fixture.invalid");
+  assert.equal(calls[0]?.proxyPort, 20_004);
+  assert.equal(calls[0]?.targetHost, "virtual-gateway.fixture.invalid");
+  assert.equal(calls[0]?.targetPort, 3_342);
+  assert.equal(calls[0]?.accessToken, FIXTURE_ACCESS_TOKEN);
+  assert.equal(calls[0]?.locationId, "berlin-1");
+  assert.equal(calls[0]?.timeoutMs, 4_321);
+  assert.equal(calls[0]?.maxBufferedBytes, 8_192);
+  assert.equal(
+    (await transport.receive({ timeoutMs: 1_000 })).toString(),
+    "first-target-frame",
+  );
+  assert.ok(initialData.every((byte) => byte === 0));
+  await transport.close();
+});
+
+test("uses the direct connection timeout when no proxy override is configured", async (t) => {
+  const { server, port } = await listen();
+  t.after(() => closeServer(server));
+  let timeout: number | undefined;
+  const factory = createConnectivitySocks5DirectCpicTransportFactory({
+    proxyHost: "connectivity-proxy.fixture.invalid",
+    proxyPort: 20_004,
+    accessToken: FIXTURE_ACCESS_TOKEN,
+  }, {
+    async connectTunnel(config): Promise<EstablishedConnectivitySocks5Tunnel> {
+      timeout = config.timeoutMs;
+      return Object.freeze({ socket: await connect(port), initialData: Buffer.alloc(0) });
+    },
+  });
+  const transport = await factory({
+    host: "virtual-gateway.fixture.invalid",
+    port: 3_300,
+    connectTimeoutMs: 2_345,
+  });
+  assert.equal(timeout, 2_345);
+  await transport.close();
+});
+
+test("validates fixed proxy options before constructing the NI factory", () => {
+  assert.throws(
+    () => createConnectivitySocks5DirectCpicTransportFactory({
+      proxyHost: "bad host",
+      proxyPort: 20_004,
+      accessToken: FIXTURE_ACCESS_TOKEN,
+    }),
+    /proxyHost/u,
+  );
+  assert.throws(
+    () => createConnectivitySocks5DirectCpicTransportFactory({
+      proxyHost: "proxy.fixture.invalid",
+      proxyPort: 20_001,
+      accessToken: FIXTURE_ACCESS_TOKEN,
+    }, { connectTunnel: 1 as never }),
+    /tunnel connector must be a function/u,
+  );
+
+  for (const invalid of [null, [], new Date()] as readonly unknown[]) {
+    assert.throws(
+      () => createConnectivitySocks5DirectCpicTransportFactory(invalid as never),
+      /plain object/u,
+    );
+  }
+  const proxied = new Proxy({
+    proxyHost: "proxy.fixture.invalid",
+    proxyPort: 20_004,
+    accessToken: FIXTURE_ACCESS_TOKEN,
+  }, {});
+  assert.throws(
+    () => createConnectivitySocks5DirectCpicTransportFactory(proxied),
+    /Proxy/u,
+  );
+  assert.throws(
+    () => createConnectivitySocks5DirectCpicTransportFactory({
+      proxyHost: "proxy.fixture.invalid",
+      proxyPort: 20_004,
+      accessToken: FIXTURE_ACCESS_TOKEN,
+      unexpected: true,
+    } as never),
+    /unsupported property unexpected/u,
+  );
+  const symbolProperty = {
+    proxyHost: "proxy.fixture.invalid",
+    proxyPort: 20_004,
+    accessToken: FIXTURE_ACCESS_TOKEN,
+    [Symbol("secret")]: "value",
+  };
+  assert.throws(
+    () => createConnectivitySocks5DirectCpicTransportFactory(symbolProperty),
+    /do not accept symbols/u,
+  );
+  const accessor = {
+    proxyHost: "proxy.fixture.invalid",
+    proxyPort: 20_004,
+    accessToken: FIXTURE_ACCESS_TOKEN,
+  };
+  Object.defineProperty(accessor, "locationId", {
+    enumerable: true,
+    get: () => "must-not-run",
+  });
+  assert.throws(
+    () => createConnectivitySocks5DirectCpicTransportFactory(accessor),
+    /locationId must be an own data property/u,
+  );
+  assert.throws(
+    () => createConnectivitySocks5DirectCpicTransportFactory({
+      proxyHost: "proxy.fixture.invalid",
+      proxyPort: 20_004,
+      accessToken: FIXTURE_ACCESS_TOKEN,
+    }, null as never),
+    /dependencies must be an object/u,
+  );
+});
+
+test("destroys invalid or unadoptable tunnel handoffs without retrying", async (t) => {
+  const proxy = {
+    proxyHost: "connectivity-proxy.fixture.invalid",
+    proxyPort: 20_004,
+    accessToken: FIXTURE_ACCESS_TOKEN,
+  } as const;
+
+  await t.test("non-object result", async () => {
+    const factory = createConnectivitySocks5DirectCpicTransportFactory(proxy, {
+      async connectTunnel(): Promise<never> {
+        return null as never;
+      },
+    });
+    await assert.rejects(
+      Promise.resolve(factory({ host: "target.fixture.invalid", port: 3_300 })),
+      /must return a tunnel/u,
+    );
+  });
+
+  await t.test("non-buffer initial data", async () => {
+    let destroyCalls = 0;
+    const socket = {
+      destroy(): void { destroyCalls += 1; },
+    };
+    const factory = createConnectivitySocks5DirectCpicTransportFactory(proxy, {
+      async connectTunnel(): Promise<EstablishedConnectivitySocks5Tunnel> {
+        return {
+          socket: socket as never,
+          initialData: "not bytes" as never,
+        };
+      },
+    });
+    await assert.rejects(
+      Promise.resolve(factory({ host: "target.fixture.invalid", port: 3_300 })),
+      /buffered initialData/u,
+    );
+    assert.equal(destroyCalls, 1);
+  });
+
+  await t.test("flowing socket", async () => {
+    const { server, port } = await listen();
+    t.after(() => closeServer(server));
+    let handedOff: Socket | undefined;
+    const initialData = encodeNiFrame(Buffer.from("must-be-wiped"));
+    const factory = createConnectivitySocks5DirectCpicTransportFactory(proxy, {
+      async connectTunnel(): Promise<EstablishedConnectivitySocks5Tunnel> {
+        handedOff = createConnection({ host: "127.0.0.1", port });
+        await new Promise<void>((resolve, reject) => {
+          handedOff!.once("connect", resolve);
+          handedOff!.once("error", reject);
+        });
+        return { socket: handedOff, initialData };
+      },
+    });
+    await assert.rejects(
+      Promise.resolve(factory({ host: "target.fixture.invalid", port: 3_300 })),
+      /paused/u,
+    );
+    assert.equal(handedOff?.destroyed, true);
+    assert.ok(initialData.every((byte) => byte === 0));
+  });
+});

--- a/test/connectivity-socks5-tunnel.test.ts
+++ b/test/connectivity-socks5-tunnel.test.ts
@@ -301,6 +301,29 @@ test("encodes an IPv4 target without resolving it and omits location ID", async 
   assert.equal(established.initialData.length, 0);
 });
 
+test("accepts an RFC 1928 IPv6 bound address in a successful reply", async () => {
+  const socket = new FakeSocket();
+  const pending = establishConnectivitySocks5Tunnel(
+    socket,
+    admitConnectivitySocks5Config(baseConfig()),
+  );
+  socket.data(Buffer.from([0x05, 0x80]));
+  socket.data(Buffer.from([0x01, 0x00]));
+  socket.data(Buffer.concat([
+    Buffer.from([0x05, 0x00, 0x00, 0x04]),
+    Buffer.alloc(16),
+    Buffer.from([0x00, 0x00]),
+    Buffer.from([0x00, 0x00, 0x00, 0x03, 0x52, 0x46, 0x43]),
+  ]));
+
+  const established = await pending;
+  assert.deepEqual(
+    established.initialData,
+    Buffer.from([0x00, 0x00, 0x00, 0x03, 0x52, 0x46, 0x43]),
+  );
+  assert.equal(socket.destroyCalls, 0);
+});
+
 test("connects a real TCP stream and completes the documented handshake", async (t) => {
   const server = createServer((peer) => {
     let phase = 0;
@@ -523,11 +546,11 @@ test("maps proxy rejections and malformed responses to redaction-safe errors", a
     ],
     "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
   ));
-  await t.test("unsupported IPv6 reply", () => rejectAfter(
+  await t.test("unsupported address type", () => rejectAfter(
     [
       Buffer.from([0x05, 0x80]),
       Buffer.from([0x01, 0x00]),
-      Buffer.from([0x05, 0x00, 0x00, 0x04]),
+      Buffer.from([0x05, 0x00, 0x00, 0x7f]),
     ],
     "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
   ));

--- a/test/connectivity-socks5-tunnel.test.ts
+++ b/test/connectivity-socks5-tunnel.test.ts
@@ -1,0 +1,809 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import {
+  createServer,
+  type Server,
+  type Socket,
+} from "node:net";
+import { inspect } from "node:util";
+
+import {
+  ConnectivitySocks5Error,
+  admitConnectivitySocks5Config,
+  assertAdmittedConnectivitySocks5Config,
+  connectConnectivitySocks5Tunnel,
+  establishConnectivitySocks5Tunnel,
+  type ConnectivitySocks5Socket,
+  type ConnectivitySocks5TimerScheduler,
+} from "../src/transport/connectivity-socks5-tunnel.js";
+
+const FIXTURE_ACCESS_TOKEN = ["header", "payload", "signature"].join(".");
+
+type Assert<T extends true> = T;
+type _NetSocketCompatibility = Assert<
+  Socket extends ConnectivitySocks5Socket ? true : false
+>;
+
+class FakeSocket extends EventEmitter implements ConnectivitySocks5Socket {
+  readonly writes: Buffer[] = [];
+  readonly writtenBuffers: Buffer[] = [];
+  readonly pendingWriteCallbacks: ((error?: Error | null) => void)[] = [];
+  destroyed = false;
+  destroyCalls = 0;
+  pauseCalls = 0;
+  autoCompleteWrites = true;
+  throwOnWrite = false;
+  throwOnPause = false;
+  throwOnDestroy = false;
+
+  write(
+    chunk: Uint8Array,
+    callback: (error?: Error | null) => void,
+  ): boolean {
+    if (this.throwOnWrite) throw new Error("fixture write failure");
+    const buffer = Buffer.isBuffer(chunk)
+      ? chunk
+      : Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+    this.writtenBuffers.push(buffer);
+    this.writes.push(Buffer.from(buffer));
+    if (this.autoCompleteWrites) callback();
+    else this.pendingWriteCallbacks.push(callback);
+    return true;
+  }
+
+  completeWrite(error?: Error): void {
+    const callback = this.pendingWriteCallbacks.shift();
+    if (callback === undefined) throw new Error("no pending fake write");
+    callback(error);
+  }
+
+  pause(): this {
+    if (this.throwOnPause) throw new Error("fixture pause failure");
+    this.pauseCalls += 1;
+    return this;
+  }
+
+  destroy(): this {
+    this.destroyCalls += 1;
+    if (this.throwOnDestroy) throw new Error("fixture destroy failure");
+    if (!this.destroyed) {
+      this.destroyed = true;
+      this.emit("close");
+    }
+    return this;
+  }
+
+  data(chunk: Buffer | string): void {
+    this.emit("data", chunk);
+  }
+}
+
+function baseConfig(): Record<string, unknown> {
+  return {
+    proxyHost: "connectivity-proxy.example.test",
+    proxyPort: 20_004,
+    targetHost: "sap-virtual.example.test",
+    targetPort: 3_300,
+    accessToken: FIXTURE_ACCESS_TOKEN,
+  };
+}
+
+function manualScheduler(): {
+  readonly scheduler: ConnectivitySocks5TimerScheduler;
+  readonly fire: () => void;
+  readonly clearCount: () => number;
+} {
+  let callback: (() => void) | undefined;
+  let clears = 0;
+  const handle = Object.freeze({ timer: "manual" });
+  return Object.freeze({
+    scheduler: Object.freeze({
+      setTimeout(next: () => void): object {
+        callback = next;
+        return handle;
+      },
+      clearTimeout(received: unknown): void {
+        assert.equal(received, handle);
+        callback = undefined;
+        clears += 1;
+      },
+    }),
+    fire(): void {
+      const next = callback;
+      callback = undefined;
+      next?.();
+    },
+    clearCount: () => clears,
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error === undefined ? resolve() : reject(error));
+  });
+}
+
+test("admits an immutable, redaction-safe SOCKS5 configuration snapshot", () => {
+  const source: Record<string, unknown> = {
+    ...baseConfig(),
+    locationId: "berlin-一",
+    timeoutMs: 2_000,
+    maxBufferedBytes: 4_096,
+  };
+  const admitted = admitConnectivitySocks5Config(source);
+  source.accessToken = ["mutated", "token", "value"].join(".");
+  source.locationId = "mutated";
+
+  assert.equal(admitted.accessToken, FIXTURE_ACCESS_TOKEN);
+  assert.equal(admitted.locationId, "berlin-一");
+  assert.equal(admitted.timeoutMs, 2_000);
+  assert.equal(admitted.maxBufferedBytes, 4_096);
+  assert.ok(Object.isFrozen(admitted));
+  assert.doesNotMatch(JSON.stringify(admitted), /header|payload|signature|berlin/u);
+  assert.doesNotMatch(inspect(admitted), /header|payload|signature|berlin/u);
+});
+
+test("rejects ambiguous input, unsupported addresses, and unbounded secrets before I/O", () => {
+  const cases: readonly [Record<string, unknown>, RegExp][] = [
+    [{} as Record<string, unknown>, /proxyHost must be an own data property/u],
+    [{ ...baseConfig(), proxyPort: 0 }, /proxyPort/u],
+    [{ ...baseConfig(), targetPort: 65_536 }, /targetPort/u],
+    [{ ...baseConfig(), proxyHost: "bad host" }, /proxyHost/u],
+    [{ ...baseConfig(), proxyHost: "[2001:db8::1" }, /invalid IP literal/u],
+    [{ ...baseConfig(), proxyHost: 42 }, /proxyHost/u],
+    [{ ...baseConfig(), targetHost: "2001:db8::1" }, /IPv6/u],
+    [{ ...baseConfig(), targetHost: "[127.0.0.1]" }, /IPv6 literal/u],
+    [{ ...baseConfig(), proxyHost: "[proxy.example.test]" }, /IPv6 literal/u],
+    [{ ...baseConfig(), targetHost: "999.1.1.1" }, /targetHost/u],
+    [{ ...baseConfig(), targetHost: "user@sap.example.test" }, /targetHost/u],
+    [{ ...baseConfig(), targetHost: `${"x".repeat(64)}.test` }, /targetHost/u],
+    [{ ...baseConfig(), accessToken: "contains whitespace" }, /accessToken/u],
+    [{ ...baseConfig(), accessToken: "" }, /accessToken/u],
+    [{ ...baseConfig(), accessToken: "x".repeat(65_537) }, /accessToken/u],
+    [{ ...baseConfig(), locationId: "" }, /locationId/u],
+    [{ ...baseConfig(), locationId: "bad\nlocation" }, /locationId/u],
+    [{ ...baseConfig(), locationId: "x".repeat(190) }, /locationId/u],
+    [{ ...baseConfig(), locationId: "一".repeat(64) }, /locationId/u],
+    [{ ...baseConfig(), timeoutMs: 0 }, /timeoutMs/u],
+    [{ ...baseConfig(), maxBufferedBytes: 7 }, /maxBufferedBytes/u],
+    [{ ...baseConfig(), extra: true }, /unsupported property extra/u],
+  ];
+  for (const [input, expected] of cases) {
+    assert.throws(() => admitConnectivitySocks5Config(input), expected);
+  }
+  for (const input of [null, [], new Date()] as const) {
+    assert.throws(
+      () => admitConnectivitySocks5Config(input as never),
+      /plain object/u,
+    );
+  }
+
+  const withSymbol = baseConfig();
+  Object.defineProperty(withSymbol, Symbol("private"), { value: true });
+  assert.throws(
+    () => admitConnectivitySocks5Config(withSymbol),
+    /symbol properties/u,
+  );
+
+  const normalized = admitConnectivitySocks5Config({
+    ...baseConfig(),
+    proxyHost: "[2001:db8::1]",
+    targetHost: "sap-virtual.example.test.",
+  });
+  assert.equal(normalized.proxyHost, "2001:db8::1");
+  assert.equal(normalized.targetHost, "sap-virtual.example.test");
+  assert.throws(
+    () => assertAdmittedConnectivitySocks5Config({ ...normalized }),
+    /must come from admitConnectivitySocks5Config/u,
+  );
+
+  let getterCalls = 0;
+  const accessor = baseConfig();
+  Object.defineProperty(accessor, "locationId", {
+    enumerable: true,
+    get() {
+      getterCalls += 1;
+      return "must-not-run";
+    },
+  });
+  assert.throws(
+    () => admitConnectivitySocks5Config(accessor),
+    /locationId must be an own data property/u,
+  );
+  assert.equal(getterCalls, 0);
+
+  const proxied = new Proxy(baseConfig(), {
+    ownKeys(): never {
+      throw new Error("Proxy trap must not execute");
+    },
+  });
+  assert.throws(() => admitConnectivitySocks5Config(proxied), /Proxy/u);
+});
+
+test("performs SAP JWT method 0x80 and preserves fragmented target bytes", async () => {
+  const socket = new FakeSocket();
+  const timers = manualScheduler();
+  const pending = establishConnectivitySocks5Tunnel(
+    socket,
+    admitConnectivitySocks5Config({
+      ...baseConfig(),
+      locationId: "berlin-1",
+    }),
+    undefined,
+    timers.scheduler,
+  );
+
+  assert.deepEqual(socket.writes, [Buffer.from([0x05, 0x01, 0x80])]);
+  socket.data(Buffer.from([0x05]));
+  assert.equal(socket.writes.length, 1);
+  socket.data(Buffer.from([0x80]));
+
+  const token = Buffer.from(FIXTURE_ACCESS_TOKEN, "ascii");
+  const encodedLocation = Buffer.from("berlin-1", "utf8").toString("base64");
+  const expectedAuth = Buffer.alloc(1 + 4 + token.length + 1 + encodedLocation.length);
+  expectedAuth[0] = 0x01;
+  expectedAuth.writeUInt32BE(token.length, 1);
+  token.copy(expectedAuth, 5);
+  expectedAuth[5 + token.length] = encodedLocation.length;
+  expectedAuth.write(encodedLocation, 6 + token.length, "ascii");
+  assert.deepEqual(socket.writes[1], expectedAuth);
+  assert.ok(socket.writtenBuffers[1]!.every((byte) => byte === 0));
+
+  socket.data(Buffer.from([0x01, 0x00]));
+  const host = Buffer.from("sap-virtual.example.test", "ascii");
+  assert.deepEqual(socket.writes[2], Buffer.concat([
+    Buffer.from([0x05, 0x01, 0x00, 0x03, host.length]),
+    host,
+    Buffer.from([0x0c, 0xe4]),
+  ]));
+
+  socket.data(Buffer.from([0x05, 0x00, 0x00]));
+  socket.data(Buffer.from([0x03, 0x05, 0x70]));
+  socket.data(Buffer.concat([
+    Buffer.from("roxy", "ascii"),
+    Buffer.from([0x4e, 0x24]),
+    Buffer.from([0x00, 0x00, 0x00, 0x03, 0x52, 0x46, 0x43]),
+  ]));
+  const established = await pending;
+
+  assert.equal(established.socket, socket);
+  assert.deepEqual(
+    established.initialData,
+    Buffer.from([0x00, 0x00, 0x00, 0x03, 0x52, 0x46, 0x43]),
+  );
+  assert.equal(socket.pauseCalls, 1);
+  assert.equal(socket.destroyCalls, 0);
+  assert.equal(timers.clearCount(), 1);
+  assert.doesNotMatch(JSON.stringify(established), /header|payload|signature/u);
+});
+
+test("encodes an IPv4 target without resolving it and omits location ID", async () => {
+  const socket = new FakeSocket();
+  const pending = establishConnectivitySocks5Tunnel(
+    socket,
+    admitConnectivitySocks5Config({
+      ...baseConfig(),
+      targetHost: "192.0.2.25",
+      targetPort: 443,
+    }),
+  );
+  socket.data(Buffer.from([0x05, 0x80]));
+  const auth = socket.writes[1]!;
+  assert.equal(auth.at(-1), 0);
+  socket.data(Buffer.from([0x01, 0x00]));
+  assert.deepEqual(
+    socket.writes[2],
+    Buffer.from([0x05, 0x01, 0x00, 0x01, 192, 0, 2, 25, 0x01, 0xbb]),
+  );
+  socket.data(Buffer.from([0x05, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0x4e, 0x24]));
+  const established = await pending;
+  assert.equal(established.initialData.length, 0);
+});
+
+test("connects a real TCP stream and completes the documented handshake", async (t) => {
+  const server = createServer((peer) => {
+    let phase = 0;
+    let buffered = Buffer.alloc(0);
+    peer.on("data", (chunk) => {
+      buffered = Buffer.concat([buffered, chunk]);
+      while (true) {
+        if (phase === 0) {
+          if (buffered.length < 3) return;
+          assert.deepEqual(buffered.subarray(0, 3), Buffer.from([0x05, 0x01, 0x80]));
+          buffered = buffered.subarray(3);
+          phase = 1;
+          peer.write(Buffer.from([0x05]));
+          peer.write(Buffer.from([0x80]));
+          continue;
+        }
+        if (phase === 1) {
+          if (buffered.length < 6) return;
+          const tokenLength = buffered.readUInt32BE(1);
+          if (buffered.length < 6 + tokenLength) return;
+          const locationLength = buffered[5 + tokenLength]!;
+          const total = 6 + tokenLength + locationLength;
+          if (buffered.length < total) return;
+          assert.equal(buffered[0], 0x01);
+          assert.equal(
+            buffered.subarray(5, 5 + tokenLength).toString("ascii"),
+            FIXTURE_ACCESS_TOKEN,
+          );
+          assert.equal(
+            buffered.subarray(6 + tokenLength, total).toString("ascii"),
+            Buffer.from("berlin-1").toString("base64"),
+          );
+          buffered = buffered.subarray(total);
+          phase = 2;
+          peer.write(Buffer.from([0x01, 0x00]));
+          continue;
+        }
+        if (phase === 2) {
+          if (buffered.length < 5) return;
+          const domainLength = buffered[4]!;
+          const total = 7 + domainLength;
+          if (buffered.length < total) return;
+          assert.equal(buffered.subarray(0, 5).toString("hex"), "05010003" + domainLength.toString(16).padStart(2, "0"));
+          assert.equal(
+            buffered.subarray(5, 5 + domainLength).toString("ascii"),
+            "sap-virtual.example.test",
+          );
+          assert.equal(buffered.readUInt16BE(5 + domainLength), 3_300);
+          buffered = buffered.subarray(total);
+          phase = 3;
+          peer.write(Buffer.concat([
+            Buffer.from([0x05, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0x4e, 0x24]),
+            Buffer.from([0x00, 0x00, 0x00, 0x02, 0x4e, 0x49]),
+          ]));
+          continue;
+        }
+        return;
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  t.after(() => closeServer(server));
+  const address = server.address();
+  assert.ok(address !== null && typeof address !== "string");
+
+  const established = await connectConnectivitySocks5Tunnel({
+    proxyHost: "127.0.0.1",
+    proxyPort: address.port,
+    targetHost: "sap-virtual.example.test",
+    targetPort: 3_300,
+    accessToken: FIXTURE_ACCESS_TOKEN,
+    locationId: "berlin-1",
+    timeoutMs: 1_000,
+  });
+  assert.deepEqual(
+    established.initialData,
+    Buffer.from([0x00, 0x00, 0x00, 0x02, 0x4e, 0x49]),
+  );
+  established.socket.destroy();
+});
+
+test("validates connector seams and destroys an invalid returned stream", async () => {
+  const config = {
+    proxyHost: "proxy.fixture.invalid",
+    proxyPort: 20_004,
+    targetHost: "target.fixture.invalid",
+    targetPort: 3_300,
+    accessToken: FIXTURE_ACCESS_TOKEN,
+  } as const;
+  await assert.rejects(
+    connectConnectivitySocks5Tunnel(config, undefined, null as never),
+    /dependencies must be an object/u,
+  );
+  await assert.rejects(
+    connectConnectivitySocks5Tunnel(config, undefined, [] as never),
+    /dependencies must be an object/u,
+  );
+  await assert.rejects(
+    connectConnectivitySocks5Tunnel(config, undefined, { connect: 1 as never }),
+    /connector must be a function/u,
+  );
+  await assert.rejects(
+    connectConnectivitySocks5Tunnel(config, undefined, {
+      async connect() { return undefined as never; },
+    }),
+    (error: unknown) =>
+      error instanceof ConnectivitySocks5Error &&
+      error.code === "CONNECTIVITY_SOCKS5_CONNECT_FAILED",
+  );
+
+  let destroyCalls = 0;
+  await assert.rejects(
+    connectConnectivitySocks5Tunnel(config, undefined, {
+      async connect() {
+        return {
+          destroy(): void { destroyCalls += 1; },
+        } as never;
+      },
+    }),
+    (error: unknown) =>
+      error instanceof ConnectivitySocks5Error &&
+      error.code === "CONNECTIVITY_SOCKS5_CONNECT_FAILED",
+  );
+  assert.equal(destroyCalls, 1);
+
+  const bounded = new ConnectivitySocks5Error(
+    "CONNECTIVITY_SOCKS5_CONNECT_TIMEOUT",
+    "bounded fixture failure",
+  );
+  await assert.rejects(
+    connectConnectivitySocks5Tunnel(config, undefined, {
+      async connect(): Promise<never> { throw bounded; },
+    }),
+    (error: unknown) => error === bounded,
+  );
+
+  const duringConnect = new AbortController();
+  await assert.rejects(
+    connectConnectivitySocks5Tunnel(config, duringConnect.signal, {
+      async connect(): Promise<never> {
+        duringConnect.abort(new Error("fixture abort"));
+        throw new Error("private connector failure");
+      },
+    }),
+    (error: unknown) =>
+      error instanceof ConnectivitySocks5Error &&
+      error.code === "CONNECTIVITY_SOCKS5_ABORTED",
+  );
+
+  const afterConnect = new AbortController();
+  const socket = new FakeSocket();
+  socket.throwOnDestroy = true;
+  await assert.rejects(
+    connectConnectivitySocks5Tunnel(
+      admitConnectivitySocks5Config(config),
+      afterConnect.signal,
+      {
+        async connect(options) {
+          assert.ok(Object.isFrozen(options));
+          afterConnect.abort(new Error("fixture abort"));
+          return socket;
+        },
+      },
+    ),
+    (error: unknown) =>
+      error instanceof ConnectivitySocks5Error &&
+      error.code === "CONNECTIVITY_SOCKS5_ABORTED",
+  );
+});
+
+test("maps proxy rejections and malformed responses to redaction-safe errors", async (t) => {
+  async function rejectAfter(
+    chunks: readonly Buffer[],
+    expectedCode: string,
+    replyCode?: number,
+  ): Promise<void> {
+    const socket = new FakeSocket();
+    const pending = establishConnectivitySocks5Tunnel(
+      socket,
+      admitConnectivitySocks5Config(baseConfig()),
+    );
+    for (const chunk of chunks) socket.data(chunk);
+    await assert.rejects(pending, (error: unknown) => {
+      assert.ok(error instanceof ConnectivitySocks5Error);
+      assert.equal(error.code, expectedCode);
+      assert.equal(error.replyCode, replyCode);
+      assert.doesNotMatch(error.message, /header|payload|signature|sap-virtual/u);
+      assert.doesNotMatch(JSON.stringify(error), /header|payload|signature|sap-virtual/u);
+      assert.doesNotMatch(inspect(error), /header|payload|signature|sap-virtual/u);
+      return true;
+    });
+    assert.equal(socket.destroyCalls, 1);
+  }
+
+  await t.test("method rejected", () => rejectAfter(
+    [Buffer.from([0x05, 0xff])],
+    "CONNECTIVITY_SOCKS5_AUTHENTICATION_REJECTED",
+  ));
+  await t.test("authentication rejected", () => rejectAfter(
+    [Buffer.from([0x05, 0x80]), Buffer.from([0x01, 0x01])],
+    "CONNECTIVITY_SOCKS5_AUTHENTICATION_REJECTED",
+  ));
+  await t.test("target forbidden", () => rejectAfter(
+    [
+      Buffer.from([0x05, 0x80]),
+      Buffer.from([0x01, 0x00]),
+      Buffer.from([0x05, 0x02, 0x00, 0x01]),
+    ],
+    "CONNECTIVITY_SOCKS5_CONNECT_REJECTED",
+    2,
+  ));
+  await t.test("malformed reserved byte", () => rejectAfter(
+    [
+      Buffer.from([0x05, 0x80]),
+      Buffer.from([0x01, 0x00]),
+      Buffer.from([0x05, 0x00, 0x01, 0x01]),
+    ],
+    "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+  ));
+  await t.test("unsupported IPv6 reply", () => rejectAfter(
+    [
+      Buffer.from([0x05, 0x80]),
+      Buffer.from([0x01, 0x00]),
+      Buffer.from([0x05, 0x00, 0x00, 0x04]),
+    ],
+    "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+  ));
+  await t.test("wrong method protocol", () => rejectAfter(
+    [Buffer.from([0x04, 0x80])],
+    "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+  ));
+  await t.test("wrong authentication protocol", () => rejectAfter(
+    [Buffer.from([0x05, 0x80]), Buffer.from([0x02, 0x00])],
+    "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+  ));
+  await t.test("empty bound domain", () => rejectAfter(
+    [
+      Buffer.from([0x05, 0x80]),
+      Buffer.from([0x01, 0x00]),
+      Buffer.from([0x05, 0x00, 0x00, 0x03, 0x00]),
+    ],
+    "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+  ));
+});
+
+test("validates socket and scheduler state and fails closed on synchronous hooks", async (t) => {
+  const config = admitConnectivitySocks5Config(baseConfig());
+  assert.throws(
+    () => establishConnectivitySocks5Tunnel(null as never, config),
+    /connected byte stream/u,
+  );
+  assert.throws(
+    () => establishConnectivitySocks5Tunnel({ destroy() {} } as never, config),
+    /connected byte stream/u,
+  );
+  assert.throws(
+    () => establishConnectivitySocks5Tunnel(new FakeSocket(), config, undefined, null as never),
+    /scheduler must be an object/u,
+  );
+  assert.throws(
+    () => establishConnectivitySocks5Tunnel(
+      new FakeSocket(),
+      config,
+      undefined,
+      { setTimeout: 1 as never, clearTimeout() {} },
+    ),
+    /must provide setTimeout and clearTimeout/u,
+  );
+
+  await t.test("timer scheduler throws", async () => {
+    const socket = new FakeSocket();
+    await assert.rejects(
+      establishConnectivitySocks5Tunnel(socket, config, undefined, {
+        setTimeout(): never { throw new Error("fixture timer failure"); },
+        clearTimeout() {},
+      }),
+      (error: unknown) =>
+        error instanceof ConnectivitySocks5Error &&
+        error.code === "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+    );
+  });
+
+  await t.test("synchronous abort during timer installation", async () => {
+    const socket = new FakeSocket();
+    const controller = new AbortController();
+    let clears = 0;
+    const pending = establishConnectivitySocks5Tunnel(
+      socket,
+      config,
+      controller.signal,
+      {
+        setTimeout() {
+          controller.abort();
+          return "fixture-handle";
+        },
+        clearTimeout(handle) {
+          assert.equal(handle, "fixture-handle");
+          clears += 1;
+        },
+      },
+    );
+    await assert.rejects(
+      pending,
+      (error: unknown) =>
+        error instanceof ConnectivitySocks5Error &&
+        error.code === "CONNECTIVITY_SOCKS5_ABORTED",
+    );
+    assert.equal(clears, 1);
+  });
+
+  await t.test("socket write throws", async () => {
+    const socket = new FakeSocket();
+    socket.throwOnWrite = true;
+    await assert.rejects(
+      establishConnectivitySocks5Tunnel(socket, config),
+      (error: unknown) =>
+        error instanceof ConnectivitySocks5Error &&
+        error.code === "CONNECTIVITY_SOCKS5_WRITE_FAILED",
+    );
+  });
+
+  await t.test("socket pause throws", async () => {
+    const socket = new FakeSocket();
+    socket.throwOnPause = true;
+    const pending = establishConnectivitySocks5Tunnel(socket, config);
+    socket.data(Buffer.from([0x05, 0x80]));
+    socket.data(Buffer.from([0x01, 0x00]));
+    const host = Buffer.from("bound", "ascii");
+    socket.data(Buffer.concat([
+      Buffer.from([0x05, 0x00, 0x00, 0x03, host.length]),
+      host,
+      Buffer.from([0x00, 0x50]),
+    ]));
+    await assert.rejects(
+      pending,
+      (error: unknown) =>
+        error instanceof ConnectivitySocks5Error &&
+        error.code === "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+    );
+  });
+
+  await t.test("partial listener installation throws", async () => {
+    const socket = new FakeSocket();
+    const originalOn = socket.on.bind(socket);
+    let registrations = 0;
+    socket.on = ((event: string, listener: (...args: unknown[]) => void) => {
+      registrations += 1;
+      if (registrations === 2) throw new Error("fixture listener failure");
+      return originalOn(event, listener);
+    }) as typeof socket.on;
+    await assert.rejects(
+      establishConnectivitySocks5Tunnel(socket, config),
+      (error: unknown) =>
+        error instanceof ConnectivitySocks5Error &&
+        error.code === "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR",
+    );
+    assert.equal(socket.destroyCalls, 1);
+    assert.equal(socket.listenerCount("data"), 0);
+  });
+
+  await t.test("throwing listener cleanup still settles and destroys", async () => {
+    const socket = new FakeSocket();
+    const originalRemove = socket.removeListener.bind(socket);
+    let threw = false;
+    socket.removeListener = ((
+      event: string,
+      listener: (...args: unknown[]) => void,
+    ) => {
+      const result = originalRemove(event, listener);
+      if (!threw) {
+        threw = true;
+        throw new Error("fixture cleanup failure");
+      }
+      return result;
+    }) as typeof socket.removeListener;
+    const controller = new AbortController();
+    const pending = establishConnectivitySocks5Tunnel(
+      socket,
+      config,
+      controller.signal,
+    );
+    controller.abort();
+    await assert.rejects(
+      pending,
+      (error: unknown) =>
+        error instanceof ConnectivitySocks5Error &&
+        error.code === "CONNECTIVITY_SOCKS5_ABORTED",
+    );
+    assert.equal(socket.destroyCalls, 1);
+  });
+});
+
+test("treats abort, timeout, EOF, invalid chunks, bounds, and write errors as fatal", async (t) => {
+  await t.test("already aborted writes nothing", async () => {
+    const socket = new FakeSocket();
+    const controller = new AbortController();
+    controller.abort(new Error("private abort reason"));
+    await assert.rejects(
+      establishConnectivitySocks5Tunnel(
+        socket,
+        admitConnectivitySocks5Config(baseConfig()),
+        controller.signal,
+      ),
+      (error: unknown) =>
+        error instanceof ConnectivitySocks5Error &&
+        error.code === "CONNECTIVITY_SOCKS5_ABORTED",
+    );
+    assert.equal(socket.writes.length, 0);
+    assert.equal(socket.destroyCalls, 1);
+  });
+
+  await t.test("abort", async () => {
+    const socket = new FakeSocket();
+    const controller = new AbortController();
+    const pending = establishConnectivitySocks5Tunnel(
+      socket,
+      admitConnectivitySocks5Config(baseConfig()),
+      controller.signal,
+    );
+    controller.abort();
+    await assert.rejects(pending, (error: unknown) =>
+      error instanceof ConnectivitySocks5Error &&
+      error.code === "CONNECTIVITY_SOCKS5_ABORTED");
+    assert.equal(socket.destroyCalls, 1);
+  });
+
+  await t.test("timeout", async () => {
+    const socket = new FakeSocket();
+    const timers = manualScheduler();
+    const pending = establishConnectivitySocks5Tunnel(
+      socket,
+      admitConnectivitySocks5Config(baseConfig()),
+      undefined,
+      timers.scheduler,
+    );
+    timers.fire();
+    await assert.rejects(pending, (error: unknown) =>
+      error instanceof ConnectivitySocks5Error &&
+      error.code === "CONNECTIVITY_SOCKS5_TIMEOUT");
+  });
+
+  for (const [name, event, code] of [
+    ["EOF", "end", "CONNECTIVITY_SOCKS5_CONNECTION_CLOSED"],
+    ["close", "close", "CONNECTIVITY_SOCKS5_CONNECTION_CLOSED"],
+    ["socket error", "error", "CONNECTIVITY_SOCKS5_CONNECTION_CLOSED"],
+  ] as const) {
+    await t.test(name, async () => {
+      const socket = new FakeSocket();
+      const pending = establishConnectivitySocks5Tunnel(
+        socket,
+        admitConnectivitySocks5Config(baseConfig()),
+      );
+      if (event === "error") socket.emit(event, new Error("socket failed"));
+      else socket.emit(event);
+      await assert.rejects(pending, (error: unknown) =>
+        error instanceof ConnectivitySocks5Error && error.code === code);
+    });
+  }
+
+  await t.test("non-buffer chunk", async () => {
+    const socket = new FakeSocket();
+    const pending = establishConnectivitySocks5Tunnel(
+      socket,
+      admitConnectivitySocks5Config(baseConfig()),
+    );
+    socket.data("must not be decoded text");
+    await assert.rejects(pending, (error: unknown) =>
+      error instanceof ConnectivitySocks5Error &&
+      error.code === "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR");
+  });
+
+  await t.test("buffer bound", async () => {
+    const socket = new FakeSocket();
+    const pending = establishConnectivitySocks5Tunnel(
+      socket,
+      admitConnectivitySocks5Config({
+        ...baseConfig(),
+        maxBufferedBytes: 8,
+      }),
+    );
+    socket.data(Buffer.alloc(9));
+    await assert.rejects(pending, (error: unknown) =>
+      error instanceof ConnectivitySocks5Error &&
+      error.code === "CONNECTIVITY_SOCKS5_PROTOCOL_ERROR");
+  });
+
+  await t.test("write failure releases token frame", async () => {
+    const socket = new FakeSocket();
+    socket.autoCompleteWrites = false;
+    const pending = establishConnectivitySocks5Tunnel(
+      socket,
+      admitConnectivitySocks5Config(baseConfig()),
+    );
+    socket.completeWrite();
+    socket.data(Buffer.from([0x05, 0x80]));
+    assert.match(socket.writtenBuffers[1]!.toString("ascii"), /header\.payload\.signature/u);
+    socket.completeWrite(new Error("failed"));
+    await assert.rejects(pending, (error: unknown) =>
+      error instanceof ConnectivitySocks5Error &&
+      error.code === "CONNECTIVITY_SOCKS5_WRITE_FAILED");
+    assert.ok(socket.writtenBuffers[1]!.every((byte) => byte === 0));
+  });
+});

--- a/test/direct-rfc-session-provider.test.ts
+++ b/test/direct-rfc-session-provider.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { DirectCpicTransportFactory } from "../src/client/direct-cpic-session.js";
+import type { DirectDestinationOwner } from "../src/destination/direct-destination-owner.js";
+import { createDirectRfcSessionProvider } from "../src/compat/direct-rfc-session-provider.js";
+import {
+  planConnectionRoute,
+  type ConnectivitySocks5Plan,
+} from "../src/compat/connection-route.js";
+import type {
+  RFCClientDestinationOwnerFactoryContext,
+} from "../src/compat/rfc-client-owner-registry.js";
+import {
+  bindRFCClientDestinationOwnerFactory,
+  resolveRFCClientDestinationOwnerFactory,
+} from "../src/compat/rfc-client-owner-registry.js";
+
+const ROUTE =
+  "/H/router.fixture.invalid/S/3299/H/";
+
+function fakeOwner(events: string[]): DirectDestinationOwner {
+  return {
+    async retire() {
+      events.push("owner:retire");
+    },
+    async getFunctionInterface() {
+      throw new Error("metadata was not expected");
+    },
+    async getStructureDefinition() {
+      throw new Error("metadata was not expected");
+    },
+  } as unknown as DirectDestinationOwner;
+}
+
+function directPlan(extra: Readonly<Record<string, unknown>> = {}) {
+  return planConnectionRoute({
+    ashost: "application.fixture.invalid",
+    sysnr: "00",
+    client: "001",
+    user: "fixture-user",
+    passwd: ["fixture", "secret"].join("-"),
+    lang: "E",
+    ...extra,
+  });
+}
+
+test("advertises and injects SAProuter only with a concrete transport", async () => {
+  const events: string[] = [];
+  const contexts: Array<RFCClientDestinationOwnerFactoryContext | undefined> = [];
+  const routeStrings: string[] = [];
+  const markerTransport = (async () => {
+    throw new Error("marker transport must stay lazy");
+  }) as DirectCpicTransportFactory;
+  const provider = createDirectRfcSessionProvider({
+    operationTimeoutMs: 1_000,
+    ownerFactory(connection, context) {
+      assert.deepEqual(connection, {
+        host: "application.fixture.invalid",
+        applicationServerHost: "application.fixture.invalid",
+        port: 3_300,
+        applicationServerService: "sapdp00",
+        client: "001",
+        user: "fixture-user",
+        password: ["fixture", "secret"].join("-"),
+        language: "E",
+        sysnr: "00",
+        cpicStreaming: "disabled",
+      });
+      contexts.push(context);
+      return fakeOwner(events);
+    },
+    sapRouterTransportFactory(routeString) {
+      routeStrings.push(routeString);
+      return markerTransport;
+    },
+  });
+
+  assert.deepEqual(provider.capabilities, [
+    "direct-rfc-transport",
+    "named-user-authentication",
+    "saprouter-routing",
+  ]);
+  const session = await provider.open(directPlan({ saprouter: ROUTE }));
+  assert.deepEqual(routeStrings, [ROUTE]);
+  assert.equal(contexts.length, 1);
+  assert.equal(contexts[0]?.session?.transportFactory, markerTransport);
+  assert.equal(Object.isFrozen(contexts[0]), true);
+  assert.equal(Object.isFrozen(contexts[0]?.session), true);
+  assert.equal(session.connectionInfo.host, "application.fixture.invalid");
+  assert.equal(session.connectionInfo.language, "E");
+  assert.equal(session.connectionInfo.isoLanguage, "EN");
+  assert.equal(session.connectionInfo.sysId, "");
+  assert.equal(session.connectionInfo.rel, "");
+  assert.equal(session.connectionInfo.partnerRel, "");
+  assert.equal(session.connectionInfo.kernelRel, "");
+  assert.equal(session.connectionInfo.cpicConvId, "");
+  await session.close();
+  assert.deepEqual(events, ["owner:retire"]);
+});
+
+test("rejects SAProuter before owner creation when no transport is composed", async () => {
+  let ownerCreations = 0;
+  const provider = createDirectRfcSessionProvider({
+    operationTimeoutMs: 1_000,
+    ownerFactory() {
+      ownerCreations += 1;
+      return fakeOwner([]);
+    },
+  });
+  assert.deepEqual(provider.capabilities, [
+    "direct-rfc-transport",
+    "named-user-authentication",
+  ]);
+  await assert.rejects(
+    provider.open(directPlan({ saprouter: ROUTE })),
+    /does not implement SAProuter/u,
+  );
+  assert.equal(ownerCreations, 0);
+});
+
+test("advertises and injects Connectivity SOCKS5 only with a concrete transport", async () => {
+  const contexts: Array<RFCClientDestinationOwnerFactoryContext | undefined> = [];
+  const proxyPlans: ConnectivitySocks5Plan[] = [];
+  const markerTransport = (async () => {
+    throw new Error("marker transport must stay lazy");
+  }) as DirectCpicTransportFactory;
+  const provider = createDirectRfcSessionProvider({
+    operationTimeoutMs: 1_000,
+    ownerFactory(_connection, context) {
+      contexts.push(context);
+      return fakeOwner([]);
+    },
+    connectivitySocks5TransportFactory(plan) {
+      proxyPlans.push(plan);
+      return markerTransport;
+    },
+  });
+  assert.deepEqual(provider.capabilities, [
+    "direct-rfc-transport",
+    "named-user-authentication",
+    "connectivity-socks5-tcp",
+  ]);
+
+  const session = await provider.open(directPlan({
+    gwhost: "virtual-gateway.invalid",
+    connectivity_socks5_proxy_host: "proxy.fixture.invalid",
+    connectivity_socks5_proxy_port: 20_004,
+    connectivity_socks5_access_token: ["connectivity", "token", "fixture"].join("-"),
+    connectivity_socks5_location_id: "location-a",
+  }));
+  assert.equal(proxyPlans.length, 1);
+  assert.equal(proxyPlans[0]?.host, "proxy.fixture.invalid");
+  assert.equal(proxyPlans[0]?.port, 20_004);
+  assert.equal(proxyPlans[0]?.locationId, "location-a");
+  assert.equal(contexts[0]?.session?.transportFactory, markerTransport);
+  await session.close();
+});
+
+test("rejects Connectivity SOCKS5 before owner creation when no transport is composed", async () => {
+  let ownerCreations = 0;
+  const provider = createDirectRfcSessionProvider({
+    operationTimeoutMs: 1_000,
+    ownerFactory() {
+      ownerCreations += 1;
+      return fakeOwner([]);
+    },
+  });
+  await assert.rejects(
+    provider.open(directPlan({
+      connectivity_socks5_proxy_host: "proxy.fixture.invalid",
+      connectivity_socks5_proxy_port: 20_004,
+      connectivity_socks5_access_token: "fixture-token",
+    })),
+    /does not implement Connectivity SOCKS5/u,
+  );
+  assert.equal(ownerCreations, 0);
+});
+
+test("rejects invalid route transport composition before owner creation", async () => {
+  let ownerCreations = 0;
+  const provider = createDirectRfcSessionProvider({
+    operationTimeoutMs: 1_000,
+    ownerFactory() {
+      ownerCreations += 1;
+      return fakeOwner([]);
+    },
+    sapRouterTransportFactory: () => 1 as never,
+  });
+  await assert.rejects(
+    provider.open(directPlan({ saprouter: ROUTE })),
+    /must return a transport function/u,
+  );
+  assert.equal(ownerCreations, 0);
+});
+
+test("rejects unsupported Connectivity before route or owner I/O", async () => {
+  let routeCreations = 0;
+  let ownerCreations = 0;
+  const provider = createDirectRfcSessionProvider({
+    operationTimeoutMs: 1_000,
+    ownerFactory() {
+      ownerCreations += 1;
+      return fakeOwner([]);
+    },
+    sapRouterTransportFactory() {
+      routeCreations += 1;
+      return (async () => {
+        throw new Error("transport must not run");
+      }) as DirectCpicTransportFactory;
+    },
+  });
+  await assert.rejects(
+    provider.open(directPlan({
+      saprouter: ROUTE,
+      connectivity_proxy_host: "proxy.fixture.invalid",
+      connectivity_proxy_port: "20001",
+    })),
+    /does not implement Connectivity/u,
+  );
+  assert.equal(routeCreations, 0);
+  assert.equal(ownerCreations, 0);
+});
+
+test("owner-factory bindings preserve the route-specific session context", async () => {
+  const client = {};
+  const contexts: Array<RFCClientDestinationOwnerFactoryContext | undefined> = [];
+  bindRFCClientDestinationOwnerFactory(client, (_connection, context) => {
+    contexts.push(context);
+    return fakeOwner([]);
+  });
+  const fallback = () => {
+    throw new Error("bound owner factory was not resolved");
+  };
+  const factory = resolveRFCClientDestinationOwnerFactory(client, fallback);
+  const plan = directPlan();
+  assert.equal(plan.route.kind, "direct");
+  const markerTransport = (async () => {
+    throw new Error("marker transport must stay lazy");
+  }) as DirectCpicTransportFactory;
+  const context = Object.freeze({
+    session: Object.freeze({ transportFactory: markerTransport }),
+  });
+  await factory({
+    host: plan.route.host,
+    applicationServerHost: plan.route.applicationServerHost,
+    port: plan.route.port,
+    applicationServerService: plan.route.applicationServerService,
+    client: plan.logon.client,
+    user: "fixture-user",
+    password: ["fixture", "secret"].join("-"),
+    language: plan.logon.language,
+    sysnr: plan.route.sysnr,
+    cpicStreaming: plan.route.cpicStreaming,
+  }, context);
+  assert.deepEqual(contexts, [context]);
+});

--- a/test/direct-rfc-session-provider.test.ts
+++ b/test/direct-rfc-session-provider.test.ts
@@ -194,6 +194,43 @@ test("rejects invalid route transport composition before owner creation", async 
   assert.equal(ownerCreations, 0);
 });
 
+test("rejects a forged SAProuter plus Connectivity plan before transport I/O", async () => {
+  let transportCreations = 0;
+  let ownerCreations = 0;
+  const provider = createDirectRfcSessionProvider({
+    operationTimeoutMs: 1_000,
+    ownerFactory() {
+      ownerCreations += 1;
+      return fakeOwner([]);
+    },
+    sapRouterTransportFactory() {
+      transportCreations += 1;
+      return (async () => undefined) as never;
+    },
+    connectivitySocks5TransportFactory() {
+      transportCreations += 1;
+      return (async () => undefined) as never;
+    },
+  });
+  const sapRouterPlan = directPlan({ saprouter: ROUTE });
+  const socksPlan = directPlan({
+    connectivity_socks5_proxy_host: "proxy.fixture.invalid",
+    connectivity_socks5_proxy_port: 20_004,
+    connectivity_socks5_access_token: "fixture-token",
+  });
+  const forged = Object.freeze({
+    ...sapRouterPlan,
+    connectivitySocks5: socksPlan.connectivitySocks5,
+  });
+
+  await assert.rejects(
+    provider.open(forged),
+    /cannot combine SAProuter and Connectivity SOCKS5/u,
+  );
+  assert.equal(transportCreations, 0);
+  assert.equal(ownerCreations, 0);
+});
+
 test("rejects unsupported Connectivity before route or owner I/O", async () => {
   let routeCreations = 0;
   let ownerCreations = 0;

--- a/test/modern-connectivity-socks5-route.test.ts
+++ b/test/modern-connectivity-socks5-route.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { inspect } from "node:util";
+import test from "node:test";
+
+import { RFCClient } from "../src/compat/node-rfc-library.js";
+import {
+  bindRFCClientDestinationOwnerFactory,
+  type RFCClientDestinationOwnerFactoryContext,
+} from "../src/compat/rfc-client-owner-registry.js";
+import { resolveRFCClientSessionProvider } from
+  "../src/compat/rfc-session-provider-registry.js";
+
+test("modern RFCClient carries Connectivity SOCKS5 into the direct session", async () => {
+  const client = new RFCClient();
+  const provider = resolveRFCClientSessionProvider(client);
+  assert.equal(provider.capabilities.includes("connectivity-socks5-tcp"), true);
+
+  let context: RFCClientDestinationOwnerFactoryContext | undefined;
+  const stop = new Error("owner creation stopped before transport I/O");
+  bindRFCClientDestinationOwnerFactory(client, (_connection, ownerContext) => {
+    context = ownerContext;
+    throw stop;
+  });
+
+  const accessToken = ["connectivity", "token", "fixture"].join("-");
+  let failure: unknown;
+  try {
+    await client.open({
+      ashost: "application.fixture.invalid",
+      gwhost: "virtual-gateway.invalid",
+      gwserv: 3_300,
+      client: "001",
+      user: "fixture-user",
+      passwd: "fixture-password",
+      connectivity_socks5_proxy_host: "proxy.fixture.invalid",
+      connectivity_socks5_proxy_port: 20_004,
+      connectivity_socks5_access_token: accessToken,
+      connectivity_socks5_location_id: "location-a",
+    });
+  } catch (error) {
+    failure = error;
+  }
+
+  assert.ok(failure instanceof Error);
+  assert.equal(typeof context?.session?.transportFactory, "function");
+  assert.doesNotMatch(inspect(failure, { depth: null }), /connectivity-token-fixture|location-a/u);
+});

--- a/test/node-rfc-connectivity-error.test.ts
+++ b/test/node-rfc-connectivity-error.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RFCError,
+  RFCErrorCode,
+} from "../src/client/rfc-errors.js";
+import { projectNodeRfcPublicError } from
+  "../src/compat/node-rfc-client.js";
+import {
+  ConnectivitySocks5Error,
+  type ConnectivitySocks5ErrorCode,
+} from "../src/transport/connectivity-socks5-tunnel.js";
+
+test("projects Connectivity SOCKS5 failures into the public RFC error contract", () => {
+  const cases: ReadonlyArray<readonly [
+    ConnectivitySocks5ErrorCode,
+    RFCErrorCode,
+    string,
+  ]> = [
+    ["CONNECTIVITY_SOCKS5_ABORTED", RFCErrorCode.RFC_CANCELED, "RFC_CANCELED"],
+    ["CONNECTIVITY_SOCKS5_CONNECT_TIMEOUT", RFCErrorCode.RFC_TIMEOUT, "RFC_TIMEOUT"],
+    ["CONNECTIVITY_SOCKS5_TIMEOUT", RFCErrorCode.RFC_TIMEOUT, "RFC_TIMEOUT"],
+    [
+      "CONNECTIVITY_SOCKS5_AUTHENTICATION_REJECTED",
+      RFCErrorCode.RFC_COMMUNICATION_FAILURE,
+      "RFC_COMMUNICATION_FAILURE",
+    ],
+    [
+      "CONNECTIVITY_SOCKS5_CONNECT_REJECTED",
+      RFCErrorCode.RFC_COMMUNICATION_FAILURE,
+      "RFC_COMMUNICATION_FAILURE",
+    ],
+  ];
+
+  for (const [sourceCode, expectedCode, expectedCodeString] of cases) {
+    const source = new ConnectivitySocks5Error(
+      sourceCode,
+      "private route detail must not reach the public facade",
+    );
+    const projected = projectNodeRfcPublicError(source);
+    assert.ok(projected instanceof RFCError);
+    assert.equal(projected.code, expectedCode);
+    assert.equal(projected.codeString, expectedCodeString);
+    assert.equal(projected.key, sourceCode);
+    assert.doesNotMatch(projected.message, /private route detail/u);
+  }
+});

--- a/test/node-rfc-public-surface.test.ts
+++ b/test/node-rfc-public-surface.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { inspect } from "node:util";
 
 import {
   ABAPError,
@@ -8,6 +9,7 @@ import {
   EnumSncQop,
   EnumTrace,
   NodeRfcError,
+  Pool,
   RFCError,
   RFCErrorCode,
   RFC_RC,
@@ -29,6 +31,42 @@ import {
   type RfcTableOfVariables,
   type RfcVariable,
 } from "../src/index.js";
+
+test("Client and Pool config snapshots do not serialize Connectivity Location IDs", () => {
+  const locationId = "location-fixture";
+  const connectionParameters = {
+    ashost: "application.example.invalid",
+    gwhost: "virtual-gateway.example.invalid",
+    gwserv: "sapgw00",
+    sysnr: "00",
+    client: "100",
+    user: "fixture-user",
+    passwd: "fixture-pw",
+    connectivity_socks5_proxy_host: "connectivity.example.invalid",
+    connectivity_socks5_proxy_port: 20_004,
+    connectivity_socks5_access_token: "connectivity-token-fixture",
+    connectivity_socks5_location_id: locationId,
+  };
+  const client = new Client(connectionParameters);
+  const pool = new Pool({ connectionParameters });
+
+  for (const [config, snapshot] of [
+    [client.config, client.config.connectionParameters],
+    [pool.config, pool.connectionParameters],
+    [pool.poolConfiguration, pool.poolConfiguration.connectionParameters],
+  ] as const) {
+    assert.equal(snapshot.connectivity_socks5_location_id, locationId);
+    assert.equal(
+      Object.getOwnPropertyDescriptor(
+        snapshot,
+        "connectivity_socks5_location_id",
+      )?.enumerable,
+      false,
+    );
+    assert.equal(JSON.stringify(config).includes(locationId), false);
+    assert.equal(inspect(config).includes(locationId), false);
+  }
+});
 
 test("exports the archived node-rfc enum surface with exact values", () => {
   assert.equal(RFC_RC, RFCErrorCode);


### PR DESCRIPTION
## Goal

Enable an ARC-1 extension running on SAP BTP Cloud Foundry to call an on-premise S/4HANA 2023 system with classic RFC through the BTP Connectivity SOCKS5 endpoint and a Cloud Connector TCP mapping.

## Content

- adds a distinct bounded Connectivity SOCKS5 tunnel and NI handoff
- wires the route into modern and classic direct named-user clients
- fails closed for partial or conflicting RFC-proxy, principal-propagation, message-server, SAProuter, and WebSocket combinations
- preserves and redacts route-changing credentials, including Cloud Connector Location IDs, in classic snapshots and diagnostics
- projects transport failures into stable public RFC errors without exposing token, location, proxy, or backend details
- documents Cloud Connector TCP setup, client-secret bindings, security boundaries, support status, research, and the reviewed plan
- adds protocol, malformed-input, cancellation, redaction, provider, compatibility, and regression coverage

This is explicitly an unsupported preview. It does not implement the separate SAP Connectivity RFC-proxy protocol, principal propagation, SNC, or X.509/mTLS token acquisition. Cloud Connector TCP mappings are opaque, so function-level authorization remains enforced by a dedicated least-privilege SAP user and exact `S_RFC` role.

## Cloud Connector contract

- configure an **ABAP System** mapping with protocol **TCP**, not RFC/RFC SNC
- expose one exact virtual host and gateway port (`33NN`); `gwhost`/`gwserv` must match those virtual values
- keep `ashost` as the actual SAP application-server identity carried by CPIC
- use `onpremise_proxy_host` and `onpremise_socks5_proxy_port`; do not use `onpremise_proxy_rfc_port`
- pass the raw OAuth token without a `Bearer ` prefix and use the exact optional Location ID
- treat the internal Cloud-Connector-to-gateway hop as classic RFC without end-to-end SNC or peer authentication

## Verification

- `npm run build`
- `npm run test:public` — 191 tests pass on a synthetic merge with current `main`
- `npm run check:docs`
- `npm run docs:site:check`
- `npm run lint`
- `npm run package:shape -- --publication-mode public-license-preflight`
- Codex Security full diff review — 21/21 source worklist rows closed; one low-severity Location ID serialization finding fixed in `35edfdb`
- live CF task: ARC-1 extension -> Connectivity SOCKS5 -> Cloud Connector TCP -> S/4HANA 2023 -> `RFC_SYSTEM_INFO`, exit 0 in 2.789 seconds

The current `main` plus this head was merged in a disposable local worktree and passed every command above. The disposable CF qualification app was deleted after the live test. No credentials, binding data, or private endpoints are included.
