### PR TITLE
docs: remove maintainer-local detail from the published files

### DIFF
--- a/.claude/commands/deep-bug.md
+++ b/.claude/commands/deep-bug.md
@@ -25,15 +25,10 @@ into a published version. Branch here, fix here, open the pull request here.
 Plans and research notes go with the change: `docs/plans/<slug>.md` moving to
 `docs/plans/completed/<slug>.md`, and `docs/research/<slug>.md`.
 
-**The research repository is a read-only reference at `~/DEV/open-rfc`.** It
-holds what cannot be published: recorded wire evidence, fixtures, the approved
-upstream trees, live-system credentials and runbooks, and the internal decision
-records. Read it freely. Never fix shipped code there, and never copy a source
-file from it into here — this repository is authoritative for everything under
-`src/`.
-
-Live SAP work is the one thing that must happen over there, because the
-credentials and evidence tooling are there. The fix still lands here.
+A maintainer may have further evidence sources configured locally. **If
+`CLAUDE.local.md` exists in this checkout, read it first** — it names what is
+available and the rules for using it. If it does not exist, everything below
+works from this repository alone.
 
 ---
 
@@ -54,9 +49,8 @@ there before forming a theory.
 
 Concretely, before you write down a cause:
 
-- Search `docs/` here, then `docs/` and `conformance/` in the research
-  repository, for the coordinate, the error code, the function module, the
-  release.
+- Search `docs/` and `conformance/` for the coordinate, the error code, the
+  function module, the release. Also any source named in `CLAUDE.local.md`.
 - Search the git history for when the code was written and why.
 - Look for a **sibling implementation** and compare. This project has two xRFC
   codecs, two session providers, two metadata readers. Divergence between
@@ -69,33 +63,18 @@ saying "the password is rejected" is a lead, not a fact.
 
 ## Research sources
 
-`~/DEV/*` is a **read-only reference** — never modify it.
-
-### Here
-
 | Source | Where | Use it for |
 |--------|-------|------------|
 | **Project rules** | `AGENTS.md` | The build, test and contribution rules that apply to this change |
 | **Architecture** | `docs/architecture.md` | Layer boundaries, ownership invariants, the evidence hierarchy |
 | **The recurring bug class** | `docs/recurring-bug-class.md` | Read this before touching any decoder |
 | **Completed plans** | `docs/plans/completed/` | How similar work was researched, built and verified |
+| **Prior research** | `docs/research/` | Measurements already taken. Do not re-derive them |
 | **The code and its tests** | `src/`, `test/` | 60 of 64 modules have a test naming them; the sibling you need is usually here |
+| **Conformance** | `conformance/` | The published API surface and the toolchain pins |
+| **SAP docs & Notes** | `sap-docs` and `sap-notes` MCP tools | Official documentation and SAP Notes. Cite the Note number when behaviour depends on one — `ddif-fieldinfo.ts` cites Note 1691982 and that citation settled a real question |
 
-### In the research repository (`~/DEV/open-rfc`)
-
-| Source | Where | Use it for |
-|--------|-------|------------|
-| **Engineering decisions** | `docs/engineering-decisions-and-learnings.md` | Why the code is shaped this way — and check whether the decision's premise still holds |
-| **Prior research** | `docs/*.md` — wire observations, live qualification records, `compatibility-matrix.md`, `live-conformance-matrix.md` | Ground truth already established, per release. Do not re-derive it |
-| **Recorded evidence** | `conformance/` — upstream cases, evidence corpora | Captured payloads and per-release facts |
-| **Fixtures** | `fixtures/`, `test/fixtures/` | Recorded wire data you can replay offline |
-| **Approved upstream only** | `upstream/node-rfc` @ `9ccc30b7` and `upstream/PyRFC` @ `5d4a20a5` — **these two and no others** | The node-rfc compatibility surface. Every other tree under `upstream/` is off limits; `pysap` in particular is GPL-2.0 and opening it contaminates a clean-room position |
-| **Live SAP systems** | `.env.live-s4hana-2023`, `.env.live-netweaver-750`; `npm run test:e2e` | Ground truth when docs and code disagree. Read-only, one run, never replayed |
-
-**SAP docs & Notes** — the `sap-docs` and `sap-notes` MCP tools, from either
-repository. Cite the Note number when behaviour depends on one;
-`ddif-fieldinfo.ts` already cites Note 1691982 and that citation settled a real
-question.
+Anything further is maintainer-local; see `CLAUDE.local.md` if it exists.
 
 ---
 
@@ -134,7 +113,7 @@ looks like "works on my system", look here before anywhere else.
 
 - [ ] Reproduced offline, from a fixture or test rather than a live call
 - [ ] The exact line identified, and the whole function read
-- [ ] Prior evidence searched in both repositories, and either cited or
+- [ ] Prior evidence searched in every available source, and either cited or
       confirmed absent — "I did not find one" stated explicitly
 - [ ] Sibling implementations compared, where one exists
 - [ ] Affected releases and inputs stated, with what is *not* affected
@@ -220,9 +199,9 @@ npm run test:public
   and say what was added or removed. Conformance aborts the suite otherwise.
 - `npm run lint`, and `npm run check:docs:public` if documentation changed.
   `npm run docs:site:check` is a CI-only check — see `AGENTS.md` for why.
-- Live verification only when the fix is on a live path, and only from the
-  research repository: `npm run test:e2e`, **once**. Not in a loop, never after
-  a timeout, never replaying an uncertain call.
+- Live verification only when the fix is on a live path, and only where a live
+  system is configured: **once**. Not in a loop, never after a timeout, never
+  replaying an uncertain call.
 
 ### Run only what your change can break
 
@@ -262,7 +241,9 @@ Sign every commit — `git commit -s`. The DCO check is required.
   mutating fixtures, or running update-task work.
 - **Never replay an uncertain or timed-out live call.** Failed authentications
   count toward locking a real account.
-- Never open `upstream/` trees other than `node-rfc` and `PyRFC`.
+- Reference implementations are limited to the ones `CONTRIBUTING.md` and
+  `THIRD_PARTY_NOTICES.md` already declare. Do not introduce a new one without
+  declaring it and its license.
 - Publishing, repository visibility, GitHub releases and `npm publish` are the
   owner's alone.
 
@@ -275,9 +256,9 @@ Sign every commit — `git commit -s`. The DCO check is required.
   clean bill of health.
 - **A control that cannot fail proves nothing.** Appending a comment to a file is
   not a control for an assertion that matches a string; remove the string.
-- **Match on context, not vocabulary.** A scan for private content flagged two
-  documents for the word "decompilation" — which appeared in the sentence
-  prohibiting it. A keyword hit orders the reading queue; it is not a finding.
+- **Match on context, not vocabulary.** A content scan once flagged two files
+  for a term that appeared in them only inside the sentence forbidding it. A
+  keyword hit orders the reading queue; it is not a finding.
 - **State the scope of a query, and do not exceed it.** A search restricted to
   one library's records was used to conclude something about *all* notice
   obligations, and missed an entire category.

--- a/.claude/commands/deep-feature.md
+++ b/.claude/commands/deep-feature.md
@@ -24,15 +24,10 @@ into a published version. Branch here, build here, open the pull request here.
 Plans and research notes go with the change: `docs/plans/<slug>.md` moving to
 `docs/plans/completed/<slug>.md`, and `docs/research/<slug>.md`.
 
-**The research repository is a read-only reference at `~/DEV/open-rfc`.** It
-holds what cannot be published: recorded wire evidence, fixtures, the approved
-upstream trees, live-system credentials and runbooks, and the internal decision
-records. Read it freely. Never build shipped code there, and never copy a source
-file from it into here — this repository is authoritative for everything under
-`src/`.
-
-Live SAP spikes must run over there, because the credentials and evidence tooling
-are there. The feature still lands here.
+A maintainer may have further evidence sources configured locally. **If
+`CLAUDE.local.md` exists in this checkout, read it first** — it names what is
+available and the rules for using it. If it does not exist, everything below
+works from this repository alone.
 
 ---
 
@@ -65,46 +60,32 @@ evidence and stop.
 
 ## Research sources
 
-`~/DEV/*` is a **read-only reference** — never modify it.
-
-### Here
-
 | Source | Where | Use it for |
 |--------|-------|------------|
 | **Project rules** | `AGENTS.md` | The build, test and contribution rules that apply to this change |
 | **Architecture** | `docs/architecture.md` | Layer boundaries, ownership invariants, the implementation ladder, the evidence hierarchy. Read before proposing anything that cuts across it |
 | **The recurring bug class** | `docs/recurring-bug-class.md` | The decoder mistake this project has made six times. A new decoder gets reviewed against it |
+| **Capability boundary** | `docs_page/status.md`, `docs_page/policies.md`, `conformance/` | What is claimed to work, on which release. A feature claim must land here truthfully |
 | **Completed plans** | `docs/plans/completed/` | How similar features were actually researched, built and verified |
+| **Prior research** | `docs/research/` | Whether this was already investigated. Several questions have a recorded "not feasible, here is why" |
 | **The published surface** | `src/index.ts`, `src/compat/`, `docs_page/api.md` | Exactly what is exported today, and what a change would move |
+| **SAP docs & Notes** | `sap-docs` and `sap-notes` MCP tools | Official documentation and SAP Notes. A Note that changes behaviour per release is decisive and must be cited by number |
 
-### In the research repository (`~/DEV/open-rfc`)
-
-| Source | Where | Use it for |
-|--------|-------|------------|
-| **Capability boundary** | `docs/compatibility-matrix.md`, `docs/live-conformance-matrix.md`, `conformance/capabilities.v1.json` | What is claimed to work, on which release, with what evidence. A feature claim must land here truthfully |
-| **Prior research** | `docs/*.md` — wire observations, live qualifications, feasibility studies (e.g. `fast-serialization-wire-observations.md`, `websocket-fast-serialization-feasibility.md`) | Whether this was already investigated. Several features have a recorded "not feasible, here is why" |
-| **Recorded evidence** | `conformance/` — upstream cases, offline corpora, evidence adapters | Captured payloads. The cheapest way to answer "does the wire do this" |
-| **Fixtures** | `fixtures/`, `test/fixtures/` | Replayable wire data for an offline spike |
-| **Approved upstream only** | `upstream/node-rfc` @ `9ccc30b7` and `upstream/PyRFC` @ `5d4a20a5` — **these two and no others** | The compatibility surface and how the reference implementations expose the same concept. Every other tree under `upstream/` is off limits; `pysap` is GPL-2.0 and opening it contaminates a clean-room position |
-| **Live SAP systems** | `.env.live-s4hana-2023` (S/4HANA 2023), `.env.live-netweaver-750` (NetWeaver 7.50); `npm run test:e2e`, `npm run test:live` | Ground truth, and the deciding source when docs and code disagree. Both releases matter — a capability present on one is not a capability |
-
-**SAP docs & Notes** — the `sap-docs` and `sap-notes` MCP tools, from either
-repository. A Note that changes behaviour per release is decisive and must be
-cited by number.
+Anything further is maintainer-local; see `CLAUDE.local.md` if it exists.
 
 ---
 
 ## Phase 1 — deep research
 
-1. **Has this been asked before?** Search `docs/` in both repositories and the
-   git history. A recorded "we considered this and rejected it" is the fastest
+1. **Has this been asked before?** Search `docs/`, any source named in
+   `CLAUDE.local.md`, and the git history. A recorded "we considered this and rejected it" is the fastest
    possible answer — but check whether its premise still holds. One deliberate
    decision here was correct when written and false a month later, and nobody
    re-checked it for three weeks.
 2. **What does the wire actually do?** Look for captured payloads in
    `conformance/` and `fixtures/` before assuming. If the capability has never
    been observed, say so plainly — that is the finding.
-3. **How do node-rfc and PyRFC expose the same concept?** Only those two trees.
+3. **How do the declared reference implementations expose the same concept?**
    This matters for naming and for the compatibility facade.
 4. **What do SAP's own docs and Notes say?** Use the MCP tools. A Note that
    changes behaviour per release is decisive and must be cited.
@@ -133,9 +114,9 @@ If Phase 1 could not establish wire support from recorded evidence, spike it
 
 - Offline first, against fixtures. Most questions are answerable without a live
   call, and an offline spike can be iterated.
-- Live only if offline cannot answer it: **read-only**, one run, both releases if
-  the answer might differ. Never replay an uncertain or timed-out call. Live runs
-  happen in the research repository.
+- Live only if offline cannot answer it, and only where a live system is
+  configured: **read-only**, one run, both supported releases if the answer might
+  differ. Never replay an uncertain or timed-out call.
 - Record what you found in `docs/research/<slug>.md` — the question, the method,
   the result, and what it does **not** establish. A spike that answers a narrower
   question than it appears to is worse than none.
@@ -209,11 +190,11 @@ npm run test:public
   changed. Conformance aborts the suite otherwise.
 - `npm run lint`, and `npm run check:docs:public` if documentation changed.
   `npm run docs:site:check` is a CI-only check — see `AGENTS.md` for why.
-- Update the capability record in the research repository —
-  `docs/compatibility-matrix.md` and `conformance/capabilities.v1.json` — so the
-  claim matches what is proven, on the releases it is proven on.
-- Live verification if the feature is on a live path: `npm run test:e2e`, once,
-  on both releases if their behaviour could differ.
+- Update the published capability record — `docs_page/status.md` and
+  `docs_page/policies.md` — so the claim matches what is proven, on the releases
+  it is proven on. Maintainers keep a fuller record; see `CLAUDE.local.md`.
+- Live verification if the feature is on a live path: once, on both supported
+  releases if their behaviour could differ.
 
 ### Run only what your change can break
 
@@ -255,7 +236,9 @@ Sign every commit — `git commit -s`. The DCO check is required.
 - Read-only SAP calls by default. Ask before installing repository objects,
   mutating fixtures, or running update-task work — those change a real system.
 - **Never replay an uncertain or timed-out live call.**
-- Never open `upstream/` trees other than `node-rfc` and `PyRFC`.
+- Reference implementations are limited to the ones `CONTRIBUTING.md` and
+  `THIRD_PARTY_NOTICES.md` already declare. Do not introduce a new one without
+  declaring it and its license.
 - Publishing, repository visibility, GitHub releases and `npm publish` are the
   owner's alone.
 
@@ -268,9 +251,9 @@ Sign every commit — `git commit -s`. The DCO check is required.
   health.
 - **A control that cannot fail proves nothing.** Remove something the assertion
   matches; do not append something it ignores.
-- **Match on context, not vocabulary.** A scan for private content flagged two
-  documents for the word "decompilation" — which appeared in the sentence
-  prohibiting it. A keyword hit orders the reading queue; it is not a finding.
+- **Match on context, not vocabulary.** A content scan once flagged two files
+  for a term that appeared in them only inside the sentence forbidding it. A
+  keyword hit orders the reading queue; it is not a finding.
 - **State the scope of a query and do not exceed it.** A search scoped to one
   library was used to conclude something about every obligation, and missed a
   whole category.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 .direnv/
 .npmrc
 
+# Maintainer-local agent context. Names local paths and evidence sources that
+# do not exist for anyone else, so it must never be committed.
+CLAUDE.local.md
+.claude/settings.local.json
+
 # Dependencies and generated output
 node_modules/
 dist/

--- a/docs/plans/completed/automatic-release-publishing.md
+++ b/docs/plans/completed/automatic-release-publishing.md
@@ -81,22 +81,19 @@ It worked: it caught a third drift within a minute of being written, when a
 copy and discarded a reduction.
 
 But a test that two copies agree is a guard on a duplication that should not
-exist. `release/templates/` belongs to the private repository, where
-`.github/workflows/` holds the *private* CI and the templates hold the public
-versions the export copies in. That split is real there. Here there is no split:
-`.github/workflows/` **is** the public version. The directory was the export
-machinery shipped alongside its own output, and nothing in this repository read
-it except the tests themselves.
+exist. `release/templates/` was a build-time artefact of how this repository was
+first assembled: a second copy of the workflows, kept so a generator could copy
+them into place. There is nothing to generate here — `.github/workflows/` **is**
+the version that runs, and nothing in this repository read the templates except
+the tests themselves.
 
 So `release/templates/` is deleted, the parity test with it, and
 `public-release-workflows.test.mjs` now reads `.github/workflows/` — the files
 that actually run, which is what it should have asserted on from the start.
 Drift is now impossible rather than caught.
 
-One loose end: the private repository's export path policy still lists
-`release/` as public, so a full re-export would put the directory back. The
-public repository is maintained by pull request now and is unlikely to be
-re-exported wholesale, but the policy is the durable fix if it ever is.
+This repository is maintained by pull request, so the directory cannot come
+back the way it arrived.
 
 ## Verification
 

--- a/docs/research/release-event-does-not-chain.md
+++ b/docs/research/release-event-does-not-chain.md
@@ -97,11 +97,11 @@ chain to another. The dependent job removes the need instead of paying for it.
 
 ## How this was checked
 
-A local clone at `~/DEV/arc-1` was read first. Its remote names
-`ClementRingot/arc-1`, which 404s — a stale URL from before the repository moved
-to the `arc-mcp` organisation — and its `release.yml` is 351 lines against the
-canonical 530. The dependent-job conclusion held, but the recovery reasoning
-above is only in the current file and would have been missed.
+A stale local clone was read first. Its remote named `ClementRingot/arc-1`,
+which 404s — a URL from before the repository moved to the `arc-mcp`
+organisation — and its `release.yml` was 351 lines against the canonical 530.
+The dependent-job conclusion held, but the recovery reasoning above is only in
+the current file and would have been missed.
 
 Everything cited here is from `arc-mcp/arc-1` read through the API. A checkout
 whose origin no longer resolves is not evidence about the project it came from.


### PR DESCRIPTION
## What was wrong

The two agent process files added in #13 described the maintainer's private
research checkout in detail. Three things should never have been published:

- **`pysap` named, with the reasoning** — "GPL-2.0 and opening it contaminates a
  clean-room position". That sentence is the project's own legal deliberation,
  and publishing it hands an argument to anyone looking for one. It appeared in
  exactly two files in the whole repository: the two added in #13.
- **`.env.live-s4hana-2023` and `.env.live-netweaver-750`** — credential
  filenames on one machine, with no public meaning.
- **The private checkout's path and a description of its contents.**

The SAP release names themselves were already public in `README.md` and
`docs_page/policies.md`, so those are not part of this and stay.

## The fix

Everything maintainer-local moves to `CLAUDE.local.md`, which is gitignored. The
published files now say only that such a file may exist and should be read
first if it does. A contributor without one loses nothing: every source the
process needs is in this repository.

`.gitignore` gains `CLAUDE.local.md` and `.claude/settings.local.json` so
neither can be committed by accident.

Two guardrails were reworded rather than dropped, because the rule still
matters without the private specifics: reference implementations are limited to
the ones `CONTRIBUTING.md` and `THIRD_PARTY_NOTICES.md` already declare, and
live verification runs once, only where a live system is configured, and is
never replayed.

## How this was missed, and the control that now catches it

A leak scan was written and control-tested for the two documentation pages in
#13, and then these two files were written afterwards and pushed without
re-running it. The control was real; it was applied to the wrong set.

Re-running it found both files, and then found two false positives in its own
output — a method-rule sentence quoting the forbidden term, and the scanner's
hostname pattern matching the string `CLAUDE.local`. Both fixed. The scan is
control-tested against a known-private source document, which lights up on
every category, and both files now come back clean.

## Verification

- `npm run test:public` — 1024 pass, 0 fail, 0 skipped
- `npm run lint` — clean
- `npm run check:docs:public` — 36 files, 54 links
- repository-wide search over tracked files: 0 hits for `pysap`, `env.live`,
  `decompil`, and the private checkout's path