### PR TITLE
feat: add bounded fast serializer decoding

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,10 @@
 open-rfc
 Copyright 2026 Marian Zeis
 
+This product includes software adapted from open-rfc-go
+(https://github.com/oisee/open-rfc-go), Copyright 2026 oisee, licensed under
+the Apache License, Version 2.0.
+
 open-rfc is an independent project. SAP, ABAP, SAP S/4HANA, and SAP
 NetWeaver are trademarks or registered trademarks of SAP SE or its affiliates.
 This project is not affiliated with, sponsored by, or endorsed by SAP SE.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ npm record identify the released source and package.
 - Common classic scalars, binary values, exact decimal strings, structures,
   tables, STRING/XSTRING, and configurable INT8/BCD projection are implemented
   for the selected classic beta. xRFC is not a beta serializer claim.
+- The source contains an internal, bounded, decode-only foundation for the fast
+  serializer and its LZ4 block wrapper. It is not a public API, is not wired
+  into client calls, and does not make WebSocket RFC or compression supported.
 - `Client`, `Pool`, and `RFCClient` cover the declared archived `node-rfc` and
   modern connector surfaces through ESM, CommonJS, and TypeScript declarations.
 - Message-server and SAProuter routing are implemented and tested offline, but

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -46,6 +46,45 @@ The compatibility interface names that `open-rfc` adds around those values do
 not occur in that pinned upstream source. All changes and adaptations in the
 two files named above were made by `open-rfc` contributors.
 
+## open-rfc-go (Apache-2.0)
+
+The following files are modified TypeScript adaptations by `open-rfc`
+contributors:
+
+- `src/protocol/lz4-block.ts`
+- `src/protocol/fast-serializer.ts`
+
+They use the bounded, decode-only fast-serializer work in `open-rfc-go` at
+commit `92d5d8f6e0a08ff7ac1580f461585cbde2a56939` as their implementation basis,
+specifically these upstream files:
+
+- `internal/fastser/lz4.go`
+- `internal/fastser/container.go`
+- `internal/fastser/record.go`
+- `internal/fastser/fields.go`
+
+The pinned upstream project carries this notice:
+
+    open-rfc-go
+    Copyright 2026 oisee (https://github.com/oisee)
+
+    Licensed under the Apache License, Version 2.0
+    https://www.apache.org/licenses/LICENSE-2.0
+    https://github.com/oisee/open-rfc-go
+
+The adaptations change the language and API, impose absolute allocation and
+record-count limits, require exact framing instead of attempting stream
+resynchronization, reject unknown tags and field types, copy exposed byte
+values, and clear temporary buffers on failure. The accompanying tests were
+authored for this project from neutral synthetic values; upstream packet
+capture fixtures are not redistributed.
+
+The public repository and npm package include a copy of the Apache License,
+Version 2.0 in their root `LICENSE` file. Unless required by applicable law or
+agreed to in writing, software distributed under the License is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied.
+
 ## Developer Certificate of Origin 1.1 (The Linux Foundation)
 
 This repository includes `DCO.md`, an unmodified verbatim copy of the Developer

--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -43,7 +43,7 @@
     "sha256": "3ced4556246b40fe4de22316ab1da7b6ae65ea0183a6a1d62e59fe08d293a041"
   },
   "subpathExportManifests": [],
-  "declarationCount": 66,
+  "declarationCount": 68,
   "declarations": [
     {
       "path": "dist/src/client/classic-invocation.d.ts",
@@ -251,9 +251,19 @@
       "sha256": "623b27b6f95213ff77ec866e01b417a2dd31afe0d9318736e47feddea45a96e0"
     },
     {
+      "path": "dist/src/protocol/fast-serializer.d.ts",
+      "bytes": 4117,
+      "sha256": "5ad0a502731437ba29b117b98068c916913615ffe482273cce4412960be266ba"
+    },
+    {
       "path": "dist/src/protocol/gateway.d.ts",
       "bytes": 1416,
       "sha256": "8a6f70e286b7785f9306740815cc27c3057329eeb5d319ea56a2fd5bf5ef4479"
+    },
+    {
+      "path": "dist/src/protocol/lz4-block.d.ts",
+      "bytes": 1223,
+      "sha256": "61d1eda7e26a9e222f388ed53152a91bda05e83fc0ffb6b17e8caf601ddb4ab9"
     },
     {
       "path": "dist/src/protocol/message-server.d.ts",
@@ -376,5 +386,5 @@
       "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "d8b6df85ee7c5d45428faab4c0b23d97e19ed8f6a815a1c36878eccb5b048342"
+  "aggregateSha256": "b93980a4d8a48a9358c306fa59592075bc574282fa36fbf262721d2eac39d6a8"
 }

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -249,22 +249,22 @@ Promote SAProuter only if selected and exact live evidence proves route parsing,
 - **Execution:** implementation
 - **Owners:** maintainer, independent-reviewer, sap-operator
 
-Promote WebSocket business calls only if a public independently implementable fast-serializer grammar exists and the full provider, wire, and live route can be qualified.
+Promote WebSocket business calls only after the Apache-licensed public decoder basis is completed into an independently reviewable fast-serializer contract and the full provider, wire, and live route can be qualified.
 
-- **Importance — medium:** WebSocket RFC is relevant to cloud routes, but its unresolved serializer boundary makes it unsuitable as a default stable-release dependency.
-- **Risk — critical:** Guessing or restricted-source derivation of the fast serializer could create protocol corruption, provenance problems, and an unmaintainable stable claim. Domains: `correctness`, `security`, `scope`, `external-dependency`, `schedule`.
-- **Effort — XL, 30–60 person-days, low confidence:** The unknown serializer grammar dominates the estimate; provider integration, wire implementation, fuzzing, and live qualification follow only if it closes.
-- **Condition:** Required only if the accepted V1 scope decision promotes WebSocket RFC into 1.0 and an independently implementable serializer contract is available.
+- **Importance — medium:** WebSocket RFC is relevant to cloud routes, but a partial decode grammar is not enough for a stable support claim.
+- **Risk — critical:** The bounded decoder covers observed containers, records, field descriptions, and the LZ4 wrapper, but request encoding, responses, exceptions, version negotiation, and integration are not yet complete. Guessing at those gaps could cause protocol corruption and an unmaintainable stable claim. Domains: `correctness`, `security`, `scope`, `external-dependency`, `schedule`.
+- **Effort — XL, 30–60 person-days, low confidence:** The public decoder basis removes one research unknown, but the complete bidirectional contract, provider integration, wire implementation, fuzzing, and live qualification remain.
+- **Condition:** Required only if the accepted V1 scope decision promotes WebSocket RFC into 1.0 and the decoder basis can be completed into an independently implementable serializer contract.
 - **Depends on:** `roadmap.v1-01.stable-support-boundary`
 - **Risk controls:**
-  - Require a public independently implementable grammar before implementation.
+  - Keep the partial decoder internal and fail closed until the complete grammar is reviewable.
   - Fail closed and keep the route unsupported if that prerequisite does not exist.
   - Run hostile framing, limits, cancellation, and two-release live matrices after implementation.
 - **Deliverables:**
-  - Independent serializer basis decision
+  - Complete and provenance-reviewed bidirectional serializer contract
   - WebSocket provider and live qualification if feasible
 - **Acceptance criteria:**
-  - The serializer grammar is public, independently implementable, and provenance-reviewed.
+  - Request, response, exception, versioning, and compression grammar is public, independently implementable, and provenance-reviewed.
   - Unsupported serializer states fail before business I/O.
   - The exact route passes hostile offline and two-release live qualification.
 

--- a/src/protocol/fast-serializer.ts
+++ b/src/protocol/fast-serializer.ts
@@ -1,0 +1,633 @@
+import { snapshotUint8Array } from "./bytes.js";
+import {
+  DEFAULT_MAX_LZ4_BLOCK_LENGTH,
+  Lz4BlockDecodeError,
+  decodeLz4Block,
+} from "./lz4-block.js";
+
+// Adapted and made strict/fail-closed for TypeScript from open-rfc-go's
+// Apache-2.0 internal/fastser codec at commit
+// 92d5d8f6e0a08ff7ac1580f461585cbde2a56939.
+
+export const FAST_SERIALIZER_PARAMETER_ITEM_ID = 0x5001;
+export const DEFAULT_MAX_FAST_SERIALIZER_ITEM_LENGTH = 0xffff;
+export const DEFAULT_MAX_FAST_SERIALIZER_ITEMS = 1_024;
+export const DEFAULT_MAX_FAST_SERIALIZER_RECORDS = 65_536;
+
+export const enum FastSerializerRecordTag {
+  Padded = 0x30,
+  Character = 0x43,
+  End = 0x45,
+  Int4 = 0x4e,
+  Descriptor = 0x50,
+  String = 0x53,
+}
+
+export const enum FastSerializerTypeCode {
+  Int1 = 0x01,
+  Int2 = 0x02,
+  Int4 = 0x03,
+  Character = 0x06,
+  Date = 0x0c,
+  Time = 0x0e,
+  Float = 0x13,
+  Raw = 0x17,
+  String = 0x18,
+  XString = 0x19,
+}
+
+export type FastSerializerProtocolErrorCode =
+  | "INVALID_ARGUMENT"
+  | "TRUNCATED_INPUT"
+  | "ITEM_LIMIT_EXCEEDED"
+  | "MALFORMED_ITEM"
+  | "COMPRESSION_LIMIT_EXCEEDED"
+  | "MALFORMED_COMPRESSION"
+  | "RECORD_LIMIT_EXCEEDED"
+  | "UNSUPPORTED_RECORD_TAG"
+  | "MALFORMED_RECORD"
+  | "MALFORMED_PARAMETER"
+  | "UNSUPPORTED_TYPE_CODE";
+
+/** A bounded protocol failure that never embeds peer-controlled payload text. */
+export class FastSerializerProtocolError extends Error {
+  readonly code: FastSerializerProtocolErrorCode;
+  readonly offset: number;
+
+  constructor(
+    code: FastSerializerProtocolErrorCode,
+    message: string,
+    offset: number,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "FastSerializerProtocolError";
+    this.code = code;
+    this.offset = offset;
+  }
+}
+
+export interface FastSerializerItem {
+  readonly id: number;
+  readonly data: Buffer;
+  readonly offset: number;
+  readonly bytesConsumed: number;
+}
+
+export interface FastSerializerItemDecodeOptions {
+  readonly maxItemLength?: number;
+  readonly maxItems?: number;
+}
+
+export interface FastSerializerCompressedBlock {
+  readonly data: Buffer;
+  readonly offset: number;
+  readonly compressedLength: number;
+  readonly uncompressedLength: number;
+  readonly bytesConsumed: number;
+}
+
+export interface FastSerializerCompressionOptions {
+  readonly maxCompressedLength?: number;
+  readonly maxUncompressedLength?: number;
+}
+
+export interface FastSerializerRecord {
+  readonly tag: FastSerializerRecordTag;
+  readonly value: Buffer;
+  readonly offset: number;
+  readonly bytesConsumed: number;
+}
+
+export interface FastSerializerRecordDecodeOptions {
+  readonly maxRecords?: number;
+}
+
+export interface FastSerializerFieldDescription {
+  readonly typeCode: FastSerializerTypeCode;
+  readonly width?: number;
+  readonly name: string;
+}
+
+export interface FastSerializerParameterAnnouncement {
+  readonly typeName: string;
+  readonly generated: boolean;
+  readonly fields: readonly FastSerializerFieldDescription[];
+  readonly offset: number;
+  readonly bytesConsumed: number;
+}
+
+const CHARACTER_FLAG = 0x80;
+const STRING_LENGTH_FLAG = 0xc000;
+const PARAMETER_HEADER = 0x44;
+const COMPRESSION_HEADER_LENGTH = 8;
+const TYPE_DESCRIPTOR_PREFIX = Buffer.from("\\TYPE=", "ascii");
+
+function configuredInteger(
+  value: number | undefined,
+  fallback: number,
+  label: string,
+  maximum: number,
+): number {
+  const selected = value ?? fallback;
+  if (
+    !Number.isSafeInteger(selected) ||
+    selected < 0 ||
+    selected > maximum
+  ) {
+    throw new FastSerializerProtocolError(
+      "INVALID_ARGUMENT",
+      `${label} must be an integer in 0..${maximum}`,
+      0,
+    );
+  }
+  return selected;
+}
+
+function inputOffset(value: number, length: number): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > length) {
+    throw new FastSerializerProtocolError(
+      "INVALID_ARGUMENT",
+      `offset must be an integer in 0..${length}`,
+      0,
+    );
+  }
+  return value;
+}
+
+function requireBytes(
+  input: Buffer,
+  offset: number,
+  length: number,
+  context: string,
+): void {
+  if (length > input.byteLength - offset) {
+    throw new FastSerializerProtocolError(
+      "TRUNCATED_INPUT",
+      `${context} is truncated at offset ${offset}`,
+      offset,
+    );
+  }
+}
+
+function decodeItemFromSnapshot(
+  input: Buffer,
+  offset: number,
+  maxItemLength: number,
+): FastSerializerItem {
+  requireBytes(input, offset, 4, "fast-serializer item header");
+  const id = input.readUInt16BE(offset);
+  const dataLength = input.readUInt16BE(offset + 2);
+  if (dataLength > maxItemLength) {
+    throw new FastSerializerProtocolError(
+      "ITEM_LIMIT_EXCEEDED",
+      `fast-serializer item length ${dataLength} exceeds configured limit ${maxItemLength}`,
+      offset,
+    );
+  }
+
+  const dataOffset = offset + 4;
+  requireBytes(
+    input,
+    dataOffset,
+    dataLength + 2,
+    "fast-serializer item payload",
+  );
+  const closingIdOffset = dataOffset + dataLength;
+  if (input.readUInt16BE(closingIdOffset) !== id) {
+    throw new FastSerializerProtocolError(
+      "MALFORMED_ITEM",
+      "fast-serializer item closing identifier does not match its opening identifier",
+      closingIdOffset,
+    );
+  }
+  return Object.freeze({
+    id,
+    data: Buffer.from(input.subarray(dataOffset, closingIdOffset)),
+    offset,
+    bytesConsumed: 6 + dataLength,
+  });
+}
+
+/** Decode one self-closing fast-serializer item at an exact offset. */
+export function decodeFastSerializerItem(
+  input: Uint8Array,
+  offset = 0,
+  options: FastSerializerItemDecodeOptions = {},
+): FastSerializerItem {
+  const snapshot = snapshotUint8Array(input, "fast-serializer item stream");
+  try {
+    return decodeItemFromSnapshot(
+      snapshot,
+      inputOffset(offset, snapshot.byteLength),
+      configuredInteger(
+        options.maxItemLength,
+        DEFAULT_MAX_FAST_SERIALIZER_ITEM_LENGTH,
+        "maxItemLength",
+        0xffff,
+      ),
+    );
+  } finally {
+    snapshot.fill(0);
+  }
+}
+
+/** Decode an exact contiguous item stream; gaps and trailing bytes are errors. */
+export function decodeFastSerializerItems(
+  input: Uint8Array,
+  options: FastSerializerItemDecodeOptions = {},
+): readonly FastSerializerItem[] {
+  const snapshot = snapshotUint8Array(input, "fast-serializer item stream");
+  try {
+    const maxItemLength = configuredInteger(
+      options.maxItemLength,
+      DEFAULT_MAX_FAST_SERIALIZER_ITEM_LENGTH,
+      "maxItemLength",
+      0xffff,
+    );
+    const maxItems = configuredInteger(
+      options.maxItems,
+      DEFAULT_MAX_FAST_SERIALIZER_ITEMS,
+      "maxItems",
+      DEFAULT_MAX_FAST_SERIALIZER_ITEMS,
+    );
+    const items: FastSerializerItem[] = [];
+    let offset = 0;
+    while (offset < snapshot.byteLength) {
+      if (items.length === maxItems) {
+        throw new FastSerializerProtocolError(
+          "ITEM_LIMIT_EXCEEDED",
+          `fast-serializer item count exceeds configured limit ${maxItems}`,
+          offset,
+        );
+      }
+      const item = decodeItemFromSnapshot(snapshot, offset, maxItemLength);
+      items.push(item);
+      offset += item.bytesConsumed;
+    }
+    return Object.freeze(items);
+  } finally {
+    snapshot.fill(0);
+  }
+}
+
+/**
+ * Decode one SAP fast-serializer LZ4 block with its two little-endian sizes.
+ * The returned byte count lets the owning grammar continue without scanning.
+ */
+export function decodeFastSerializerCompressedBlock(
+  input: Uint8Array,
+  offset = 0,
+  options: FastSerializerCompressionOptions = {},
+): FastSerializerCompressedBlock {
+  const snapshot = snapshotUint8Array(input, "fast-serializer compressed block");
+  try {
+    const start = inputOffset(offset, snapshot.byteLength);
+    requireBytes(snapshot, start, COMPRESSION_HEADER_LENGTH, "compression header");
+    const uncompressedLength = snapshot.readUInt32LE(start);
+    const compressedLength = snapshot.readUInt32LE(start + 4);
+    const maxCompressedLength = configuredInteger(
+      options.maxCompressedLength,
+      DEFAULT_MAX_LZ4_BLOCK_LENGTH,
+      "maxCompressedLength",
+      DEFAULT_MAX_LZ4_BLOCK_LENGTH,
+    );
+    const maxUncompressedLength = configuredInteger(
+      options.maxUncompressedLength,
+      DEFAULT_MAX_LZ4_BLOCK_LENGTH,
+      "maxUncompressedLength",
+      DEFAULT_MAX_LZ4_BLOCK_LENGTH,
+    );
+    if (
+      compressedLength === 0 ||
+      uncompressedLength === 0 ||
+      compressedLength > uncompressedLength
+    ) {
+      throw new FastSerializerProtocolError(
+        "MALFORMED_COMPRESSION",
+        "fast-serializer compression sizes are inconsistent",
+        start,
+      );
+    }
+    if (
+      compressedLength > maxCompressedLength ||
+      uncompressedLength > maxUncompressedLength
+    ) {
+      throw new FastSerializerProtocolError(
+        "COMPRESSION_LIMIT_EXCEEDED",
+        "fast-serializer compressed block exceeds configured limits",
+        start,
+      );
+    }
+    const blockOffset = start + COMPRESSION_HEADER_LENGTH;
+    requireBytes(
+      snapshot,
+      blockOffset,
+      compressedLength,
+      "fast-serializer compressed block",
+    );
+    let data: Buffer;
+    try {
+      data = decodeLz4Block(
+        snapshot.subarray(blockOffset, blockOffset + compressedLength),
+        uncompressedLength,
+        {
+          maxInputLength: maxCompressedLength,
+          maxOutputLength: maxUncompressedLength,
+        },
+      );
+    } catch (error) {
+      if (!(error instanceof Lz4BlockDecodeError)) throw error;
+      throw new FastSerializerProtocolError(
+        "MALFORMED_COMPRESSION",
+        "fast-serializer LZ4 block is malformed",
+        blockOffset,
+        { cause: error },
+      );
+    }
+    return Object.freeze({
+      data,
+      offset: start,
+      compressedLength,
+      uncompressedLength,
+      bytesConsumed: COMPRESSION_HEADER_LENGTH + compressedLength,
+    });
+  } finally {
+    snapshot.fill(0);
+  }
+}
+
+function decodeRecordFromSnapshot(
+  input: Buffer,
+  offset: number,
+): FastSerializerRecord {
+  requireBytes(input, offset, 1, "fast-serializer record tag");
+  const tag = input[offset]! as FastSerializerRecordTag;
+  let valueOffset = offset + 1;
+  let valueLength: number;
+
+  switch (tag) {
+    case FastSerializerRecordTag.End:
+      return Object.freeze({
+        tag,
+        value: Buffer.alloc(0),
+        offset,
+        bytesConsumed: 1,
+      });
+    case FastSerializerRecordTag.Int4:
+      valueLength = 4;
+      break;
+    case FastSerializerRecordTag.Descriptor:
+      requireBytes(input, valueOffset, 1, "descriptor record length");
+      valueLength = input[valueOffset]!;
+      valueOffset += 1;
+      break;
+    case FastSerializerRecordTag.Character:
+      requireBytes(input, valueOffset, 2, "character record header");
+      valueLength = input[valueOffset]!;
+      if (input[valueOffset + 1] !== CHARACTER_FLAG) {
+        throw new FastSerializerProtocolError(
+          "MALFORMED_RECORD",
+          "fast-serializer character record has an invalid flag",
+          valueOffset + 1,
+        );
+      }
+      valueOffset += 2;
+      break;
+    case FastSerializerRecordTag.Padded:
+      requireBytes(input, valueOffset, 2, "padded record length");
+      valueLength = input.readUInt16BE(valueOffset);
+      valueOffset += 2;
+      break;
+    case FastSerializerRecordTag.String: {
+      requireBytes(input, valueOffset, 4, "string record lengths");
+      const flaggedLength = input.readUInt16LE(valueOffset);
+      const plainLength = input.readUInt16LE(valueOffset + 2);
+      if (
+        (flaggedLength & STRING_LENGTH_FLAG) !== STRING_LENGTH_FLAG ||
+        (flaggedLength & 0x3fff) !== plainLength
+      ) {
+        throw new FastSerializerProtocolError(
+          "MALFORMED_RECORD",
+          "fast-serializer string record length fields disagree",
+          valueOffset,
+        );
+      }
+      valueLength = plainLength;
+      valueOffset += 4;
+      break;
+    }
+    default:
+      throw new FastSerializerProtocolError(
+        "UNSUPPORTED_RECORD_TAG",
+        `fast-serializer record tag 0x${input[offset]!.toString(16).padStart(2, "0")} is unsupported`,
+        offset,
+      );
+  }
+
+  if (valueLength === 0) {
+    throw new FastSerializerProtocolError(
+      "MALFORMED_RECORD",
+      "fast-serializer value record must not have an empty value",
+      offset,
+    );
+  }
+  requireBytes(input, valueOffset, valueLength, "fast-serializer record value");
+  return Object.freeze({
+    tag,
+    value: Buffer.from(input.subarray(valueOffset, valueOffset + valueLength)),
+    offset,
+    bytesConsumed: valueOffset + valueLength - offset,
+  });
+}
+
+/** Decode one known record at an exact offset without scanning for tag bytes. */
+export function decodeFastSerializerRecord(
+  input: Uint8Array,
+  offset = 0,
+): FastSerializerRecord {
+  const snapshot = snapshotUint8Array(input, "fast-serializer record stream");
+  try {
+    return decodeRecordFromSnapshot(
+      snapshot,
+      inputOffset(offset, snapshot.byteLength),
+    );
+  } finally {
+    snapshot.fill(0);
+  }
+}
+
+/** Decode an exact stream of known records; unknown bytes fail closed. */
+export function decodeFastSerializerRecords(
+  input: Uint8Array,
+  options: FastSerializerRecordDecodeOptions = {},
+): readonly FastSerializerRecord[] {
+  const snapshot = snapshotUint8Array(input, "fast-serializer record stream");
+  try {
+    const maxRecords = configuredInteger(
+      options.maxRecords,
+      DEFAULT_MAX_FAST_SERIALIZER_RECORDS,
+      "maxRecords",
+      DEFAULT_MAX_FAST_SERIALIZER_RECORDS,
+    );
+    const records: FastSerializerRecord[] = [];
+    let offset = 0;
+    while (offset < snapshot.byteLength) {
+      if (records.length === maxRecords) {
+        throw new FastSerializerProtocolError(
+          "RECORD_LIMIT_EXCEEDED",
+          `fast-serializer record count exceeds configured limit ${maxRecords}`,
+          offset,
+        );
+      }
+      const record = decodeRecordFromSnapshot(snapshot, offset);
+      records.push(record);
+      offset += record.bytesConsumed;
+    }
+    return Object.freeze(records);
+  } finally {
+    snapshot.fill(0);
+  }
+}
+
+export function fastSerializerTypeName(
+  record: FastSerializerRecord,
+): string | undefined {
+  if (
+    record.tag !== FastSerializerRecordTag.Descriptor ||
+    record.value.byteLength <= TYPE_DESCRIPTOR_PREFIX.byteLength ||
+    !record.value.subarray(0, TYPE_DESCRIPTOR_PREFIX.byteLength)
+      .equals(TYPE_DESCRIPTOR_PREFIX)
+  ) {
+    return undefined;
+  }
+  const raw = record.value.subarray(TYPE_DESCRIPTOR_PREFIX.byteLength);
+  if (!isPlainName(raw, true)) return undefined;
+  return raw.toString("ascii");
+}
+
+function isPlainName(
+  value: Uint8Array,
+  allowGeneratedTypeMarker = false,
+): boolean {
+  if (value.byteLength === 0) return false;
+  for (let index = 0; index < value.byteLength; index += 1) {
+    const byte = value[index]!;
+    const valid =
+      (byte >= 0x41 && byte <= 0x5a) ||
+      (byte >= 0x30 && byte <= 0x39) ||
+      byte === 0x5f ||
+      byte === 0x2f ||
+      (allowGeneratedTypeMarker && index === 0 && byte === 0x25);
+    if (!valid) return false;
+  }
+  return true;
+}
+
+function knownTypeCode(value: number): value is FastSerializerTypeCode {
+  return value === FastSerializerTypeCode.Int1 ||
+    value === FastSerializerTypeCode.Int2 ||
+    value === FastSerializerTypeCode.Int4 ||
+    value === FastSerializerTypeCode.Character ||
+    value === FastSerializerTypeCode.Date ||
+    value === FastSerializerTypeCode.Time ||
+    value === FastSerializerTypeCode.Float ||
+    value === FastSerializerTypeCode.Raw ||
+    value === FastSerializerTypeCode.String ||
+    value === FastSerializerTypeCode.XString;
+}
+
+function decodeParameterFromSnapshot(
+  input: Buffer,
+  offset: number,
+): FastSerializerParameterAnnouncement {
+  requireBytes(input, offset, 2, "fast-serializer parameter header");
+  if (input[offset] !== PARAMETER_HEADER) {
+    throw new FastSerializerProtocolError(
+      "MALFORMED_PARAMETER",
+      "fast-serializer parameter does not begin with its description header",
+      offset,
+    );
+  }
+  const fieldCount = input[offset + 1]!;
+  let cursor = offset + 2;
+  const descriptor = decodeRecordFromSnapshot(input, cursor);
+  const typeName = fastSerializerTypeName(descriptor);
+  if (typeName === undefined) {
+    throw new FastSerializerProtocolError(
+      "MALFORMED_PARAMETER",
+      "fast-serializer parameter lacks a valid type descriptor",
+      cursor,
+    );
+  }
+  cursor += descriptor.bytesConsumed;
+
+  const fields: FastSerializerFieldDescription[] = [];
+  for (let index = 0; index < fieldCount; index += 1) {
+    requireBytes(input, cursor, 1, "fast-serializer field type code");
+    const rawTypeCode = input[cursor]!;
+    cursor += 1;
+    if (!knownTypeCode(rawTypeCode)) {
+      throw new FastSerializerProtocolError(
+        "UNSUPPORTED_TYPE_CODE",
+        `fast-serializer type code 0x${rawTypeCode.toString(16).padStart(2, "0")} is unsupported`,
+        cursor - 1,
+      );
+    }
+    let width: number | undefined;
+    if (
+      rawTypeCode === FastSerializerTypeCode.Character ||
+      rawTypeCode === FastSerializerTypeCode.Raw
+    ) {
+      requireBytes(input, cursor, 2, "fast-serializer field width");
+      width = input.readUInt16LE(cursor);
+      cursor += 2;
+    }
+
+    requireBytes(input, cursor, 1, "fast-serializer field name length");
+    const nameLength = input[cursor]!;
+    cursor += 1;
+    requireBytes(input, cursor, nameLength, "fast-serializer field name");
+    const rawName = input.subarray(cursor, cursor + nameLength);
+    if (!isPlainName(rawName)) {
+      throw new FastSerializerProtocolError(
+        "MALFORMED_PARAMETER",
+        "fast-serializer field name is not a plain protocol identifier",
+        cursor,
+      );
+    }
+    fields.push(Object.freeze({
+      typeCode: rawTypeCode,
+      ...(width === undefined ? {} : { width }),
+      name: rawName.toString("ascii"),
+    }));
+    cursor += nameLength;
+  }
+
+  return Object.freeze({
+    typeName,
+    generated: typeName.startsWith("%_T"),
+    fields: Object.freeze(fields),
+    offset,
+    bytesConsumed: cursor - offset,
+  });
+}
+
+/** Decode one exact field-description announcement without guessing its end. */
+export function decodeFastSerializerParameterAnnouncement(
+  input: Uint8Array,
+  offset = 0,
+): FastSerializerParameterAnnouncement {
+  const snapshot = snapshotUint8Array(
+    input,
+    "fast-serializer parameter announcement",
+  );
+  try {
+    return decodeParameterFromSnapshot(
+      snapshot,
+      inputOffset(offset, snapshot.byteLength),
+    );
+  } finally {
+    snapshot.fill(0);
+  }
+}

--- a/src/protocol/lz4-block.ts
+++ b/src/protocol/lz4-block.ts
@@ -1,7 +1,11 @@
 import { snapshotUint8Array } from "./bytes.js";
 
-/** Default allocation ceiling for one independently compressed LZ4 block. */
-export const DEFAULT_MAX_LZ4_BLOCK_LENGTH = 16 * 1024 * 1024;
+// Adapted and hardened for TypeScript from open-rfc-go's Apache-2.0
+// internal/fastser/lz4.go at 92d5d8f6e0a08ff7ac1580f461585cbde2a56939.
+
+/** Absolute allocation ceiling for one independently compressed LZ4 block. */
+export const MAX_LZ4_BLOCK_LENGTH = 16 * 1024 * 1024;
+export const DEFAULT_MAX_LZ4_BLOCK_LENGTH = MAX_LZ4_BLOCK_LENGTH;
 
 export type Lz4BlockDecodeErrorCode =
   | "INVALID_LENGTH"
@@ -51,10 +55,14 @@ function boundedLength(
 
 function configuredLimit(value: number | undefined, label: string): number {
   const limit = value ?? DEFAULT_MAX_LZ4_BLOCK_LENGTH;
-  if (!Number.isSafeInteger(limit) || limit < 0) {
+  if (
+    !Number.isSafeInteger(limit) ||
+    limit < 0 ||
+    limit > MAX_LZ4_BLOCK_LENGTH
+  ) {
     throw new Lz4BlockDecodeError(
       "INVALID_LENGTH",
-      `${label} must be a non-negative safe integer`,
+      `${label} must be an integer in 0..${MAX_LZ4_BLOCK_LENGTH}`,
     );
   }
   return limit;

--- a/src/protocol/lz4-block.ts
+++ b/src/protocol/lz4-block.ts
@@ -1,0 +1,206 @@
+import { snapshotUint8Array } from "./bytes.js";
+
+/** Default allocation ceiling for one independently compressed LZ4 block. */
+export const DEFAULT_MAX_LZ4_BLOCK_LENGTH = 16 * 1024 * 1024;
+
+export type Lz4BlockDecodeErrorCode =
+  | "INVALID_LENGTH"
+  | "INPUT_LIMIT_EXCEEDED"
+  | "OUTPUT_LIMIT_EXCEEDED"
+  | "TRUNCATED_INPUT"
+  | "INVALID_OFFSET"
+  | "OUTPUT_LENGTH_MISMATCH"
+  | "OUTPUT_OVERRUN";
+
+/** A bounded, non-payload-bearing failure from the LZ4 block decoder. */
+export class Lz4BlockDecodeError extends Error {
+  readonly code: Lz4BlockDecodeErrorCode;
+
+  constructor(code: Lz4BlockDecodeErrorCode, message: string) {
+    super(message);
+    this.name = "Lz4BlockDecodeError";
+    this.code = code;
+  }
+}
+
+export interface Lz4BlockDecodeOptions {
+  readonly maxInputLength?: number;
+  readonly maxOutputLength?: number;
+}
+
+function boundedLength(
+  value: number,
+  label: string,
+  maximum: number,
+  maximumCode: Lz4BlockDecodeErrorCode,
+): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Lz4BlockDecodeError(
+      "INVALID_LENGTH",
+      `${label} must be a non-negative safe integer`,
+    );
+  }
+  if (value > maximum) {
+    throw new Lz4BlockDecodeError(
+      maximumCode,
+      `${label} ${value} exceeds configured limit ${maximum}`,
+    );
+  }
+  return value;
+}
+
+function configuredLimit(value: number | undefined, label: string): number {
+  const limit = value ?? DEFAULT_MAX_LZ4_BLOCK_LENGTH;
+  if (!Number.isSafeInteger(limit) || limit < 0) {
+    throw new Lz4BlockDecodeError(
+      "INVALID_LENGTH",
+      `${label} must be a non-negative safe integer`,
+    );
+  }
+  return limit;
+}
+
+/**
+ * Decode one raw LZ4 block into exactly `outputLength` bytes.
+ *
+ * LZ4 blocks carry neither framing nor their decoded size. Both the complete
+ * compressed block and its independently bounded output length must therefore
+ * come from the owning protocol layer. This implements the published LZ4 block
+ * grammar, not the separate LZ4 frame format.
+ */
+export function decodeLz4Block(
+  input: Uint8Array,
+  outputLength: number,
+  options: Lz4BlockDecodeOptions = {},
+): Buffer {
+  const maxInputLength = configuredLimit(
+    options.maxInputLength,
+    "maxInputLength",
+  );
+  const maxOutputLength = configuredLimit(
+    options.maxOutputLength,
+    "maxOutputLength",
+  );
+  const source = snapshotUint8Array(input, "LZ4 block");
+  let output: Buffer | undefined;
+
+  try {
+    boundedLength(
+      source.byteLength,
+      "LZ4 input length",
+      maxInputLength,
+      "INPUT_LIMIT_EXCEEDED",
+    );
+    boundedLength(
+      outputLength,
+      "LZ4 output length",
+      maxOutputLength,
+      "OUTPUT_LIMIT_EXCEEDED",
+    );
+    if (source.byteLength === 0) {
+      throw new Lz4BlockDecodeError(
+        "TRUNCATED_INPUT",
+        "LZ4 block is missing its first sequence token",
+      );
+    }
+
+    output = Buffer.allocUnsafe(outputLength);
+    let sourceOffset = 0;
+    let outputOffset = 0;
+
+    const readExtendedLength = (base: number, kind: "literal" | "match"): number => {
+      let length = base;
+      if (base !== 15) return length;
+      while (true) {
+        const extension = source[sourceOffset];
+        if (extension === undefined) {
+          throw new Lz4BlockDecodeError(
+            "TRUNCATED_INPUT",
+            `LZ4 ${kind} length extension is truncated`,
+          );
+        }
+        sourceOffset += 1;
+        length += extension;
+        if (!Number.isSafeInteger(length) || length > maxOutputLength) {
+          throw new Lz4BlockDecodeError(
+            "OUTPUT_OVERRUN",
+            `LZ4 ${kind} length exceeds the configured output bound`,
+          );
+        }
+        if (extension !== 0xff) return length;
+      }
+    };
+
+    while (sourceOffset < source.byteLength) {
+      const token = source[sourceOffset]!;
+      sourceOffset += 1;
+
+      const literalLength = readExtendedLength(token >>> 4, "literal");
+      if (literalLength > source.byteLength - sourceOffset) {
+        throw new Lz4BlockDecodeError(
+          "TRUNCATED_INPUT",
+          "LZ4 literal run extends past the compressed block",
+        );
+      }
+      if (literalLength > outputLength - outputOffset) {
+        throw new Lz4BlockDecodeError(
+          "OUTPUT_OVERRUN",
+          "LZ4 literal run exceeds the declared output length",
+        );
+      }
+      source.copy(
+        output,
+        outputOffset,
+        sourceOffset,
+        sourceOffset + literalLength,
+      );
+      sourceOffset += literalLength;
+      outputOffset += literalLength;
+
+      // The final sequence contains literals only and ends with the block.
+      if (sourceOffset === source.byteLength) break;
+      if (source.byteLength - sourceOffset < 2) {
+        throw new Lz4BlockDecodeError(
+          "TRUNCATED_INPUT",
+          "LZ4 match offset is truncated",
+        );
+      }
+
+      const matchOffset = source.readUInt16LE(sourceOffset);
+      sourceOffset += 2;
+      if (matchOffset === 0 || matchOffset > outputOffset) {
+        throw new Lz4BlockDecodeError(
+          "INVALID_OFFSET",
+          "LZ4 match offset does not reference decoded output",
+        );
+      }
+
+      const matchLength = readExtendedLength(token & 0x0f, "match") + 4;
+      if (matchLength > outputLength - outputOffset) {
+        throw new Lz4BlockDecodeError(
+          "OUTPUT_OVERRUN",
+          "LZ4 match exceeds the declared output length",
+        );
+      }
+
+      // LZ4 explicitly permits overlapping copies, including offset-one runs.
+      for (let index = 0; index < matchLength; index += 1) {
+        output[outputOffset] = output[outputOffset - matchOffset]!;
+        outputOffset += 1;
+      }
+    }
+
+    if (outputOffset !== outputLength) {
+      throw new Lz4BlockDecodeError(
+        "OUTPUT_LENGTH_MISMATCH",
+        `LZ4 block produced ${outputOffset} bytes; expected ${outputLength}`,
+      );
+    }
+    return output;
+  } catch (error) {
+    output?.fill(0);
+    throw error;
+  } finally {
+    source.fill(0);
+  }
+}

--- a/test/fast-serializer.test.ts
+++ b/test/fast-serializer.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  FAST_SERIALIZER_PARAMETER_ITEM_ID,
+  FastSerializerProtocolError,
+  FastSerializerRecordTag,
+  FastSerializerTypeCode,
+  decodeFastSerializerCompressedBlock,
+  decodeFastSerializerItem,
+  decodeFastSerializerItems,
+  decodeFastSerializerParameterAnnouncement,
+  decodeFastSerializerRecord,
+  decodeFastSerializerRecords,
+  fastSerializerTypeName,
+} from "../src/protocol/fast-serializer.js";
+
+function item(id: number, data: Uint8Array): Buffer {
+  const encoded = Buffer.alloc(6 + data.byteLength);
+  encoded.writeUInt16BE(id, 0);
+  encoded.writeUInt16BE(data.byteLength, 2);
+  Buffer.from(data).copy(encoded, 4);
+  encoded.writeUInt16BE(id, 4 + data.byteLength);
+  return encoded;
+}
+
+function compressed(block: Uint8Array, uncompressedLength: number): Buffer {
+  const encoded = Buffer.alloc(8 + block.byteLength);
+  encoded.writeUInt32LE(uncompressedLength, 0);
+  encoded.writeUInt32LE(block.byteLength, 4);
+  Buffer.from(block).copy(encoded, 8);
+  return encoded;
+}
+
+const COMPRESSED_RUN = Buffer.from([
+  0x1f, 0x78, 0x01, 0x00, 0x00,
+  0x50, 0x74, 0x61, 0x69, 0x6c, 0x21,
+]);
+const UNCOMPRESSED_RUN = Buffer.from(`${"x".repeat(20)}tail!`);
+
+function descriptor(typeName: string): Buffer {
+  const value = Buffer.from(`\\TYPE=${typeName}`, "ascii");
+  return Buffer.concat([
+    Buffer.from([FastSerializerRecordTag.Descriptor, value.byteLength]),
+    value,
+  ]);
+}
+
+test("decodes exact self-closing items without mistaking a closing id for an opener", () => {
+  const first = item(FAST_SERIALIZER_PARAMETER_ITEM_ID, Buffer.from("payload"));
+  const second = item(0x0130, Buffer.from("program"));
+  const stream = Buffer.concat([first, second]);
+  const decoded = decodeFastSerializerItems(stream);
+
+  assert.deepEqual(decoded.map(({ id, data }) => [id, data.toString()]), [
+    [FAST_SERIALIZER_PARAMETER_ITEM_ID, "payload"],
+    [0x0130, "program"],
+  ]);
+  assert.equal(decodeFastSerializerItem(stream, first.byteLength).id, 0x0130);
+  assert.throws(
+    () => decodeFastSerializerItem(stream, first.byteLength - 2),
+    (error: unknown) =>
+      error instanceof FastSerializerProtocolError,
+  );
+});
+
+test("rejects malformed, truncated, and over-budget items", () => {
+  const valid = item(0x5001, Buffer.from("abc"));
+  const wrongClose = Buffer.from(valid);
+  wrongClose.writeUInt16BE(0x5002, wrongClose.byteLength - 2);
+
+  assert.throws(() => decodeFastSerializerItems(valid.subarray(0, 3)), /truncated/u);
+  assert.throws(() => decodeFastSerializerItems(wrongClose), /does not match/u);
+  assert.throws(
+    () => decodeFastSerializerItems(valid, { maxItemLength: 2 }),
+    (error: unknown) =>
+      error instanceof FastSerializerProtocolError &&
+      error.code === "ITEM_LIMIT_EXCEEDED",
+  );
+  assert.throws(
+    () => decodeFastSerializerItems(Buffer.concat([valid, valid]), { maxItems: 1 }),
+    /item count exceeds/u,
+  );
+});
+
+test("decodes a header-bounded LZ4 block and reports its exact extent", () => {
+  const expected = UNCOMPRESSED_RUN;
+  const prefix = Buffer.from([0xde, 0xad]);
+  const suffix = Buffer.from([0xbe, 0xef]);
+  const encoded = compressed(COMPRESSED_RUN, expected.byteLength);
+  const decoded = decodeFastSerializerCompressedBlock(
+    Buffer.concat([prefix, encoded, suffix]),
+    prefix.byteLength,
+  );
+
+  assert.deepEqual(decoded.data, expected);
+  assert.equal(decoded.offset, prefix.byteLength);
+  assert.equal(decoded.uncompressedLength, expected.byteLength);
+  assert.equal(decoded.bytesConsumed, encoded.byteLength);
+});
+
+test("rejects inconsistent, truncated, corrupt, and oversized compression headers", () => {
+  const expected = UNCOMPRESSED_RUN;
+  const valid = compressed(COMPRESSED_RUN, expected.byteLength);
+
+  const zero = Buffer.from(valid);
+  zero.writeUInt32LE(0, 4);
+  assert.throws(() => decodeFastSerializerCompressedBlock(zero), /inconsistent/u);
+
+  const inverted = Buffer.from(valid);
+  inverted.writeUInt32LE(1, 0);
+  assert.throws(() => decodeFastSerializerCompressedBlock(inverted), /inconsistent/u);
+
+  assert.throws(
+    () => decodeFastSerializerCompressedBlock(valid.subarray(0, -1)),
+    /truncated/u,
+  );
+
+  const corrupt = Buffer.from(valid);
+  corrupt.fill(0, 8);
+  assert.throws(
+    () => decodeFastSerializerCompressedBlock(corrupt),
+    (error: unknown) =>
+      error instanceof FastSerializerProtocolError &&
+      error.code === "MALFORMED_COMPRESSION",
+  );
+
+  assert.throws(
+    () => decodeFastSerializerCompressedBlock(valid, 0, {
+      maxUncompressedLength: expected.byteLength - 1,
+    }),
+    /exceeds configured limits/u,
+  );
+});
+
+test("decodes every established record framing rule as one strict stream", () => {
+  const desc = descriptor("SYNTHETIC_TYPE");
+  const character = Buffer.from([
+    FastSerializerRecordTag.Character, 3, 0x80, 0x41, 0x42, 0x43,
+  ]);
+  const int4 = Buffer.from([
+    FastSerializerRecordTag.Int4, 0x00, 0x01, 0x00, 0x00,
+  ]);
+  const padded = Buffer.from([
+    FastSerializerRecordTag.Padded, 0x00, 0x04, 0x41, 0x00, 0x42, 0x00,
+  ]);
+  const string = Buffer.from([
+    FastSerializerRecordTag.String,
+    0x08, 0xc0, 0x08, 0x00,
+    ...Buffer.from("open-rfc"),
+  ]);
+  const end = Buffer.from([FastSerializerRecordTag.End]);
+  const records = decodeFastSerializerRecords(
+    Buffer.concat([desc, character, int4, padded, string, end]),
+  );
+
+  assert.equal(fastSerializerTypeName(records[0]!), "SYNTHETIC_TYPE");
+  assert.equal(records[1]!.value.toString(), "ABC");
+  assert.equal(records[2]!.value.readUInt32LE(), 256);
+  assert.equal(records[3]!.value.toString("utf16le"), "AB");
+  assert.equal(records[4]!.value.toString(), "open-rfc");
+  assert.equal(records[5]!.value.byteLength, 0);
+});
+
+test("fails closed on unsupported, malformed, empty, and truncated records", () => {
+  const cases: readonly [Buffer, string][] = [
+    [Buffer.of(0x99), "unsupported"],
+    [Buffer.from([FastSerializerRecordTag.Character, 1, 0, 0x41]), "invalid flag"],
+    [Buffer.from([FastSerializerRecordTag.Character, 0, 0x80]), "empty value"],
+    [Buffer.from([FastSerializerRecordTag.Int4, 1, 2, 3]), "truncated"],
+    [Buffer.from([FastSerializerRecordTag.String, 1, 0xc0, 2, 0, 0x41]), "disagree"],
+  ];
+  for (const [encoded, message] of cases) {
+    assert.throws(() => decodeFastSerializerRecord(encoded), new RegExp(message, "u"));
+  }
+  assert.throws(
+    () => decodeFastSerializerRecords(Buffer.from([
+      FastSerializerRecordTag.End,
+      FastSerializerRecordTag.End,
+    ]), { maxRecords: 1 }),
+    /record count exceeds/u,
+  );
+});
+
+test("decodes a synthetic field-description list with both width conventions", () => {
+  const encoded = Buffer.concat([
+    Buffer.from([0x44, 4]),
+    descriptor("Z_NEUTRAL"),
+    Buffer.from([
+      FastSerializerTypeCode.Int4, 3, 0x4e, 0x55, 0x4d,
+      FastSerializerTypeCode.Character, 20, 0, 4, 0x54, 0x45, 0x58, 0x54,
+      FastSerializerTypeCode.Raw, 3, 0, 3, 0x52, 0x41, 0x57,
+      FastSerializerTypeCode.String, 6, 0x44, 0x59, 0x4e, 0x54, 0x58, 0x54,
+    ]),
+  ]);
+  const announcement = decodeFastSerializerParameterAnnouncement(encoded);
+
+  assert.equal(announcement.typeName, "Z_NEUTRAL");
+  assert.equal(announcement.generated, false);
+  assert.equal(announcement.bytesConsumed, encoded.byteLength);
+  assert.deepEqual(announcement.fields, [
+    { typeCode: FastSerializerTypeCode.Int4, name: "NUM" },
+    { typeCode: FastSerializerTypeCode.Character, width: 20, name: "TEXT" },
+    { typeCode: FastSerializerTypeCode.Raw, width: 3, name: "RAW" },
+    { typeCode: FastSerializerTypeCode.String, name: "DYNTXT" },
+  ]);
+});
+
+test("recognizes generated descriptors and rejects unknown field grammars", () => {
+  const generated = Buffer.concat([
+    Buffer.from([0x44, 0]),
+    descriptor("%_T00001"),
+  ]);
+  assert.equal(
+    decodeFastSerializerParameterAnnouncement(generated).generated,
+    true,
+  );
+
+  const unknownType = Buffer.concat([
+    Buffer.from([0x44, 1]),
+    descriptor("Z_UNKNOWN"),
+    Buffer.from([0xff, 1, 0x41]),
+  ]);
+  assert.throws(
+    () => decodeFastSerializerParameterAnnouncement(unknownType),
+    (error: unknown) =>
+      error instanceof FastSerializerProtocolError &&
+      error.code === "UNSUPPORTED_TYPE_CODE",
+  );
+
+  const malformedName = Buffer.concat([
+    Buffer.from([0x44, 1]),
+    descriptor("Z_NAME"),
+    Buffer.from([FastSerializerTypeCode.Int4, 3, 0x41, 0x2d, 0x42]),
+  ]);
+  assert.throws(
+    () => decodeFastSerializerParameterAnnouncement(malformedName),
+    /plain protocol identifier/u,
+  );
+});
+
+test("arbitrary short protocol inputs terminate inside fixed limits", () => {
+  let state = 0x4653_4552;
+  const random = (): number => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return state >>> 0;
+  };
+
+  for (let run = 0; run < 2_048; run += 1) {
+    const input = Buffer.alloc(random() % 97);
+    for (let index = 0; index < input.byteLength; index += 1) {
+      input[index] = random() & 0xff;
+    }
+    for (const decode of [
+      () => decodeFastSerializerItems(input, { maxItems: 8, maxItemLength: 96 }),
+      () => decodeFastSerializerRecords(input, { maxRecords: 32 }),
+      () => decodeFastSerializerParameterAnnouncement(input),
+    ]) {
+      try {
+        decode();
+      } catch (error) {
+        assert.ok(error instanceof FastSerializerProtocolError);
+      }
+    }
+  }
+});

--- a/test/lz4-block.test.ts
+++ b/test/lz4-block.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_MAX_LZ4_BLOCK_LENGTH,
+  Lz4BlockDecodeError,
+  decodeLz4Block,
+} from "../src/protocol/lz4-block.js";
+
+function literalBlock(value: Uint8Array): Buffer {
+  const lengthBytes: number[] = [];
+  if (value.byteLength >= 15) {
+    let remaining = value.byteLength - 15;
+    while (remaining >= 0xff) {
+      lengthBytes.push(0xff);
+      remaining -= 0xff;
+    }
+    lengthBytes.push(remaining);
+  }
+  return Buffer.concat([
+    Buffer.from([Math.min(value.byteLength, 15) << 4, ...lengthBytes]),
+    Buffer.from(value),
+  ]);
+}
+
+test("decodes literal-only LZ4 blocks across extended-length boundaries", () => {
+  for (const length of [0, 1, 14, 15, 16, 269, 270, 271, 525]) {
+    const expected = Buffer.alloc(length);
+    for (let index = 0; index < expected.byteLength; index += 1) {
+      expected[index] = (index * 29 + 7) & 0xff;
+    }
+    assert.deepEqual(decodeLz4Block(literalBlock(expected), length), expected);
+  }
+});
+
+test("decodes an overlapping offset-one match", () => {
+  // One literal followed by a 19-byte overlapping match, producing 20 x bytes.
+  const compressed = Buffer.from([0x1f, 0x78, 0x01, 0x00, 0x00]);
+  assert.equal(decodeLz4Block(compressed, 20).toString(), "x".repeat(20));
+});
+
+test("decodes multiple sequences and an extended match", () => {
+  // abc + a 19-byte match at offset 3, then the required literals-only tail.
+  const compressed = Buffer.from([
+    0x3f, 0x61, 0x62, 0x63, 0x03, 0x00, 0x00,
+    0x50, 0x74, 0x61, 0x69, 0x6c, 0x21,
+  ]);
+  assert.equal(
+    decodeLz4Block(compressed, 27).toString(),
+    "abcabcabcabcabcabcabcatail!",
+  );
+});
+
+test("rejects corrupt, truncated, oversized, and size-mismatched blocks", () => {
+  const cases: readonly [Uint8Array, number, string][] = [
+    [Buffer.alloc(0), 0, "missing its first sequence token"],
+    [Buffer.from([0xf0, 0xff]), 1, "length extension is truncated"],
+    [Buffer.from([0x20, 0x61]), 2, "literal run extends past"],
+    [Buffer.from([0x10, 0x61, 0x00]), 5, "match offset is truncated"],
+    [Buffer.from([0x10, 0x61, 0x00, 0x00]), 5, "does not reference"],
+    [Buffer.from([0x10, 0x61, 0x02, 0x00]), 5, "does not reference"],
+    [Buffer.from([0x50, 1, 2, 3, 4, 5]), 4, "literal run exceeds"],
+    [Buffer.from([0x10, 0x61, 0x01, 0x00]), 4, "match exceeds"],
+    [literalBlock(Buffer.from("short")), 6, "produced 5 bytes"],
+  ];
+
+  for (const [input, outputLength, message] of cases) {
+    assert.throws(
+      () => decodeLz4Block(input, outputLength),
+      (error: unknown) =>
+        error instanceof Lz4BlockDecodeError &&
+        error.message.includes(message),
+    );
+  }
+
+  assert.throws(
+    () => decodeLz4Block(Buffer.of(0), DEFAULT_MAX_LZ4_BLOCK_LENGTH + 1),
+    (error: unknown) =>
+      error instanceof Lz4BlockDecodeError &&
+      error.code === "OUTPUT_LIMIT_EXCEEDED",
+  );
+  assert.throws(
+    () => decodeLz4Block(Buffer.alloc(9), 0, { maxInputLength: 8 }),
+    (error: unknown) =>
+      error instanceof Lz4BlockDecodeError &&
+      error.code === "INPUT_LIMIT_EXCEEDED",
+  );
+});
+
+test("uses intrinsic input geometry and returns unaliased output", () => {
+  class HostileGeometry extends Uint8Array {
+    override get byteLength(): number {
+      throw new Error("caller byteLength getter must not run");
+    }
+  }
+
+  const expected = Buffer.from("bounded-copy");
+  const compressed = new HostileGeometry(literalBlock(expected));
+  const decoded = decodeLz4Block(compressed, expected.byteLength);
+  compressed.fill(0);
+  assert.deepEqual(decoded, expected);
+});
+
+test("arbitrary short inputs either decode within bounds or fail safely", () => {
+  let state = 0x4c5a_3421;
+  const random = (): number => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return state >>> 0;
+  };
+
+  for (let run = 0; run < 2_048; run += 1) {
+    const input = Buffer.alloc(random() % 65);
+    for (let index = 0; index < input.byteLength; index += 1) {
+      input[index] = random() & 0xff;
+    }
+    const outputLength = random() % 257;
+    try {
+      const decoded = decodeLz4Block(input, outputLength, {
+        maxInputLength: 64,
+        maxOutputLength: 256,
+      });
+      assert.equal(decoded.byteLength, outputLength);
+    } catch (error) {
+      assert.ok(error instanceof Lz4BlockDecodeError);
+    }
+  }
+});


### PR DESCRIPTION
## Goal

Add a small, strict decode-only foundation for SAP fast serialization without changing the supported client or public package API.

## Content

- add a bounded raw LZ4 block decoder
- decode exact self-closing items, compressed blocks, known records, and field-description announcements
- fail closed on unknown framing, tags, types, mismatched lengths, and configured limits
- use synthetic hostile-input tests only; no upstream capture fixtures are redistributed
- adapt the Apache-2.0 open-rfc-go fast serializer work at commit `92d5d8f6e0a08ff7ac1580f461585cbde2a56939` and preserve its notice
- keep the codec internal and document that WebSocket RFC and compression remain unsupported

## Validation

- `npm test` — 927 passed
- `npm run lint`
- `npm run test:surface` — 20 passed
- `npm run docs:build`
- `npm pack --dry-run --ignore-scripts`
- upstream `go test ./internal/fastser`
- fresh read-only classic RFC regression on the approved S/4HANA 2023 target
- structural parity against the Go projects public live-derived fast-serializer corpus

A fresh end-to-end WebSocket RFC call is not claimed: the approved target currently has no remotely callable fast-RFC driver, and this change does not alter SAP configuration or add the missing transport/invocation path.