### PR TITLE
feat: add fast serializer encoding primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,10 @@ npm record identify the released source and package.
 - Common classic scalars, binary values, exact decimal strings, structures,
   tables, STRING/XSTRING, and configurable INT8/BCD projection are implemented
   for the selected classic beta. xRFC is not a beta serializer claim.
-- The source contains an internal, bounded, decode-only foundation for the fast
-  serializer and its LZ4 block wrapper. It is not a public API, is not wired
-  into client calls, and does not make WebSocket RFC or compression supported.
+- The source contains an internal, bounded foundation for decoding and encoding
+  established fast-serializer items, records, and field announcements, plus a
+  decode-only LZ4 block wrapper. It is not a public API, is not wired into
+  client calls, and does not make WebSocket RFC or compression supported.
 - `Client`, `Pool`, and `RFCClient` cover the declared archived `node-rfc` and
   modern connector surfaces through ESM, CommonJS, and TypeScript declarations.
 - Message-server and SAProuter routing are implemented and tested offline, but

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -54,7 +54,7 @@ contributors:
 - `src/protocol/lz4-block.ts`
 - `src/protocol/fast-serializer.ts`
 
-They use the bounded, decode-only fast-serializer work in `open-rfc-go` at
+They use the bounded fast-serializer work in `open-rfc-go` at
 commit `92d5d8f6e0a08ff7ac1580f461585cbde2a56939` as their implementation basis,
 specifically these upstream files:
 
@@ -75,9 +75,12 @@ The pinned upstream project carries this notice:
 The adaptations change the language and API, impose absolute allocation and
 record-count limits, require exact framing instead of attempting stream
 resynchronization, reject unknown tags and field types, copy exposed byte
-values, and clear temporary buffers on failure. The accompanying tests were
-authored for this project from neutral synthetic values; upstream packet
-capture fixtures are not redistributed.
+values, and clear temporary buffers on failure. Record encoding adapts the
+upstream `EncodeRecord` framing while rejecting rather than truncating values;
+the strict item, STRING, record-stream, and field-announcement encoders are
+TypeScript additions built from the same decoded grammar. The accompanying
+tests were authored for this project from neutral synthetic values; upstream
+packet-capture fixtures are not redistributed.
 
 The public repository and npm package include a copy of the Apache License,
 Version 2.0 in their root `LICENSE` file. Unless required by applicable law or

--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -252,8 +252,8 @@
     },
     {
       "path": "dist/src/protocol/fast-serializer.d.ts",
-      "bytes": 4117,
-      "sha256": "5ad0a502731437ba29b117b98068c916913615ffe482273cce4412960be266ba"
+      "bytes": 5283,
+      "sha256": "a6eb58f5dea3c5b9c0a906a206d508c6caa54de96d58082e45752c650808763f"
     },
     {
       "path": "dist/src/protocol/gateway.d.ts",
@@ -386,5 +386,5 @@
       "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "b93980a4d8a48a9358c306fa59592075bc574282fa36fbf262721d2eac39d6a8"
+  "aggregateSha256": "b828c787b439b95e962af0787fd43d43d1144c4186cc17089f6431e4038a1eb4"
 }

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -249,12 +249,12 @@ Promote SAProuter only if selected and exact live evidence proves route parsing,
 - **Execution:** implementation
 - **Owners:** maintainer, independent-reviewer, sap-operator
 
-Promote WebSocket business calls only after the Apache-licensed public decoder basis is completed into an independently reviewable fast-serializer contract and the full provider, wire, and live route can be qualified.
+Promote WebSocket business calls only after the Apache-licensed public codec basis is completed into an independently reviewable fast-serializer contract and the full provider, wire, and live route can be qualified.
 
-- **Importance — medium:** WebSocket RFC is relevant to cloud routes, but a partial decode grammar is not enough for a stable support claim.
-- **Risk — critical:** The bounded decoder covers observed containers, records, field descriptions, and the LZ4 wrapper, but request encoding, responses, exceptions, version negotiation, and integration are not yet complete. Guessing at those gaps could cause protocol corruption and an unmaintainable stable claim. Domains: `correctness`, `security`, `scope`, `external-dependency`, `schedule`.
-- **Effort — XL, 30–60 person-days, low confidence:** The public decoder basis removes one research unknown, but the complete bidirectional contract, provider integration, wire implementation, fuzzing, and live qualification remain.
-- **Condition:** Required only if the accepted V1 scope decision promotes WebSocket RFC into 1.0 and the decoder basis can be completed into an independently implementable serializer contract.
+- **Importance — medium:** WebSocket RFC is relevant to cloud routes, but low-level decode and encode primitives are not enough for a stable support claim.
+- **Risk — critical:** The bounded codec covers observed containers, records, field descriptions, and LZ4 decoding, but complete parameter-graph encoding, responses, exceptions, compression production, version negotiation, and integration are not yet complete. Guessing at those gaps could cause protocol corruption and an unmaintainable stable claim. Domains: `correctness`, `security`, `scope`, `external-dependency`, `schedule`.
+- **Effort — XL, 30–60 person-days, low confidence:** The public codec basis removes several research unknowns, but the complete bidirectional contract, provider integration, wire implementation, fuzzing, and live qualification remain.
+- **Condition:** Required only if the accepted V1 scope decision promotes WebSocket RFC into 1.0 and the codec basis can be completed into an independently implementable serializer contract.
 - **Depends on:** `roadmap.v1-01.stable-support-boundary`
 - **Risk controls:**
   - Keep the partial decoder internal and fail closed until the complete grammar is reviewable.

--- a/src/protocol/fast-serializer.ts
+++ b/src/protocol/fast-serializer.ts
@@ -103,6 +103,15 @@ export interface FastSerializerRecordDecodeOptions {
   readonly maxRecords?: number;
 }
 
+export interface FastSerializerRecordEncodeOptions {
+  readonly maxRecords?: number;
+}
+
+export interface FastSerializerRecordInput {
+  readonly tag: FastSerializerRecordTag;
+  readonly value: Uint8Array;
+}
+
 export interface FastSerializerFieldDescription {
   readonly typeCode: FastSerializerTypeCode;
   readonly width?: number;
@@ -117,10 +126,16 @@ export interface FastSerializerParameterAnnouncement {
   readonly bytesConsumed: number;
 }
 
+export interface FastSerializerParameterAnnouncementInput {
+  readonly typeName: string;
+  readonly fields: readonly FastSerializerFieldDescription[];
+}
+
 const CHARACTER_FLAG = 0x80;
 const STRING_LENGTH_FLAG = 0xc000;
 const PARAMETER_HEADER = 0x44;
 const COMPRESSION_HEADER_LENGTH = 8;
+const MAX_STRING_RECORD_LENGTH = 0x3fff;
 const TYPE_DESCRIPTOR_PREFIX = Buffer.from("\\TYPE=", "ascii");
 
 function configuredInteger(
@@ -266,6 +281,38 @@ export function decodeFastSerializerItems(
       offset += item.bytesConsumed;
     }
     return Object.freeze(items);
+  } finally {
+    snapshot.fill(0);
+  }
+}
+
+/** Encode one exact self-closing item without retaining caller-owned bytes. */
+export function encodeFastSerializerItem(
+  id: number,
+  data: Uint8Array,
+): Buffer {
+  if (!Number.isSafeInteger(id) || id < 0 || id > 0xffff) {
+    throw new FastSerializerProtocolError(
+      "INVALID_ARGUMENT",
+      "fast-serializer item identifier must be an integer in 0..65535",
+      0,
+    );
+  }
+  const snapshot = snapshotUint8Array(data, "fast-serializer item data");
+  try {
+    if (snapshot.byteLength > 0xffff) {
+      throw new FastSerializerProtocolError(
+        "ITEM_LIMIT_EXCEEDED",
+        "fast-serializer item data exceeds the 65535-byte wire limit",
+        0,
+      );
+    }
+    const encoded = Buffer.allocUnsafe(snapshot.byteLength + 6);
+    encoded.writeUInt16BE(id, 0);
+    encoded.writeUInt16BE(snapshot.byteLength, 2);
+    snapshot.copy(encoded, 4);
+    encoded.writeUInt16BE(id, snapshot.byteLength + 4);
+    return encoded;
   } finally {
     snapshot.fill(0);
   }
@@ -490,6 +537,134 @@ export function decodeFastSerializerRecords(
   }
 }
 
+/** Encode one record using only the established tag-specific framing rules. */
+export function encodeFastSerializerRecord(
+  tag: FastSerializerRecordTag,
+  value: Uint8Array = Buffer.alloc(0),
+): Buffer {
+  const snapshot = snapshotUint8Array(value, "fast-serializer record value");
+  try {
+    let headerLength: number;
+    switch (tag) {
+      case FastSerializerRecordTag.End:
+        if (snapshot.byteLength !== 0) {
+          throw new FastSerializerProtocolError(
+            "MALFORMED_RECORD",
+            "fast-serializer end record must not carry a value",
+            0,
+          );
+        }
+        return Buffer.of(tag);
+      case FastSerializerRecordTag.Int4:
+        if (snapshot.byteLength !== 4) {
+          throw new FastSerializerProtocolError(
+            "MALFORMED_RECORD",
+            "fast-serializer INT4 record value must be exactly four bytes",
+            0,
+          );
+        }
+        headerLength = 1;
+        break;
+      case FastSerializerRecordTag.Descriptor:
+        if (snapshot.byteLength === 0 || snapshot.byteLength > 0xff) {
+          throw new FastSerializerProtocolError(
+            "MALFORMED_RECORD",
+            "fast-serializer descriptor value must be 1..255 bytes",
+            0,
+          );
+        }
+        headerLength = 2;
+        break;
+      case FastSerializerRecordTag.Character:
+        if (snapshot.byteLength === 0 || snapshot.byteLength > 0xff) {
+          throw new FastSerializerProtocolError(
+            "MALFORMED_RECORD",
+            "fast-serializer character value must be 1..255 bytes",
+            0,
+          );
+        }
+        headerLength = 3;
+        break;
+      case FastSerializerRecordTag.Padded:
+        if (snapshot.byteLength === 0 || snapshot.byteLength > 0xffff) {
+          throw new FastSerializerProtocolError(
+            "MALFORMED_RECORD",
+            "fast-serializer padded value must be 1..65535 bytes",
+            0,
+          );
+        }
+        headerLength = 3;
+        break;
+      case FastSerializerRecordTag.String:
+        if (
+          snapshot.byteLength === 0 ||
+          snapshot.byteLength > MAX_STRING_RECORD_LENGTH
+        ) {
+          throw new FastSerializerProtocolError(
+            "MALFORMED_RECORD",
+            "fast-serializer string value must be 1..16383 bytes",
+            0,
+          );
+        }
+        headerLength = 5;
+        break;
+      default:
+        throw new FastSerializerProtocolError(
+          "UNSUPPORTED_RECORD_TAG",
+          `fast-serializer record tag 0x${Number(tag).toString(16).padStart(2, "0")} is unsupported`,
+          0,
+        );
+    }
+
+    const encoded = Buffer.allocUnsafe(headerLength + snapshot.byteLength);
+    encoded[0] = tag;
+    switch (tag) {
+      case FastSerializerRecordTag.Descriptor:
+        encoded[1] = snapshot.byteLength;
+        break;
+      case FastSerializerRecordTag.Character:
+        encoded[1] = snapshot.byteLength;
+        encoded[2] = CHARACTER_FLAG;
+        break;
+      case FastSerializerRecordTag.Padded:
+        encoded.writeUInt16BE(snapshot.byteLength, 1);
+        break;
+      case FastSerializerRecordTag.String:
+        encoded.writeUInt16LE(STRING_LENGTH_FLAG | snapshot.byteLength, 1);
+        encoded.writeUInt16LE(snapshot.byteLength, 3);
+        break;
+      default:
+        break;
+    }
+    snapshot.copy(encoded, headerLength);
+    return encoded;
+  } finally {
+    snapshot.fill(0);
+  }
+}
+
+/** Encode an exact contiguous record stream with a bounded record count. */
+export function encodeFastSerializerRecords(
+  records: readonly FastSerializerRecordInput[],
+  options: FastSerializerRecordEncodeOptions = {},
+): Buffer {
+  const maxRecords = configuredInteger(
+    options.maxRecords,
+    DEFAULT_MAX_FAST_SERIALIZER_RECORDS,
+    "maxRecords",
+    DEFAULT_MAX_FAST_SERIALIZER_RECORDS,
+  );
+  if (records.length > maxRecords) {
+    throw new FastSerializerProtocolError(
+      "RECORD_LIMIT_EXCEEDED",
+      `fast-serializer record count exceeds configured limit ${maxRecords}`,
+      0,
+    );
+  }
+  return Buffer.concat(records.map(({ tag, value }) =>
+    encodeFastSerializerRecord(tag, value)));
+}
+
 export function fastSerializerTypeName(
   record: FastSerializerRecord,
 ): string | undefined {
@@ -630,4 +805,128 @@ export function decodeFastSerializerParameterAnnouncement(
   } finally {
     snapshot.fill(0);
   }
+}
+
+/** Encode one strict field-description announcement from neutral metadata. */
+export function encodeFastSerializerParameterAnnouncement(
+  announcement: FastSerializerParameterAnnouncementInput,
+): Buffer {
+  const typeNameText = announcement.typeName;
+  const fields = announcement.fields;
+  if (typeof typeNameText !== "string") {
+    throw new FastSerializerProtocolError(
+      "MALFORMED_PARAMETER",
+      "fast-serializer type name must be a plain protocol identifier",
+      0,
+    );
+  }
+  if (!Array.isArray(fields)) {
+    throw new FastSerializerProtocolError(
+      "MALFORMED_PARAMETER",
+      "fast-serializer fields must be an array",
+      0,
+    );
+  }
+  const typeName = Buffer.from(typeNameText, "ascii");
+  if (
+    typeName.byteLength !== typeNameText.length ||
+    !isPlainName(typeName, true)
+  ) {
+    throw new FastSerializerProtocolError(
+      "MALFORMED_PARAMETER",
+      "fast-serializer type name must be a plain protocol identifier",
+      0,
+    );
+  }
+  const descriptorLength =
+    TYPE_DESCRIPTOR_PREFIX.byteLength + typeName.byteLength;
+  if (descriptorLength > 0xff) {
+    throw new FastSerializerProtocolError(
+      "MALFORMED_PARAMETER",
+      "fast-serializer type name exceeds the descriptor wire limit",
+      0,
+    );
+  }
+  if (fields.length > 0xff) {
+    throw new FastSerializerProtocolError(
+      "MALFORMED_PARAMETER",
+      "fast-serializer field count exceeds the 255-field wire limit",
+      0,
+    );
+  }
+
+  const parts: Buffer[] = [
+    Buffer.from([PARAMETER_HEADER, fields.length]),
+    encodeFastSerializerRecord(
+      FastSerializerRecordTag.Descriptor,
+      Buffer.concat([TYPE_DESCRIPTOR_PREFIX, typeName]),
+    ),
+  ];
+  for (const field of fields) {
+    const typeCode = field.typeCode;
+    const width = field.width;
+    const fieldName = field.name;
+    if (!knownTypeCode(typeCode)) {
+      throw new FastSerializerProtocolError(
+        "UNSUPPORTED_TYPE_CODE",
+        `fast-serializer type code 0x${Number(typeCode).toString(16).padStart(2, "0")} is unsupported`,
+        0,
+      );
+    }
+    if (typeof fieldName !== "string") {
+      throw new FastSerializerProtocolError(
+        "MALFORMED_PARAMETER",
+        "fast-serializer field name must be a 1..255-byte plain protocol identifier",
+        0,
+      );
+    }
+    const name = Buffer.from(fieldName, "ascii");
+    if (
+      name.byteLength !== fieldName.length ||
+      name.byteLength > 0xff ||
+      !isPlainName(name)
+    ) {
+      throw new FastSerializerProtocolError(
+        "MALFORMED_PARAMETER",
+        "fast-serializer field name must be a 1..255-byte plain protocol identifier",
+        0,
+      );
+    }
+    const widthParameterized =
+      typeCode === FastSerializerTypeCode.Character ||
+      typeCode === FastSerializerTypeCode.Raw;
+    if (widthParameterized) {
+      if (
+        width === undefined ||
+        !Number.isSafeInteger(width) ||
+        width < 0 ||
+        width > 0xffff
+      ) {
+        throw new FastSerializerProtocolError(
+          "MALFORMED_PARAMETER",
+          "fast-serializer character and raw fields require a width in 0..65535",
+          0,
+        );
+      }
+      const encoded = Buffer.allocUnsafe(name.byteLength + 4);
+      encoded[0] = typeCode;
+      encoded.writeUInt16LE(width, 1);
+      encoded[3] = name.byteLength;
+      name.copy(encoded, 4);
+      parts.push(encoded);
+      continue;
+    }
+    if (width !== undefined) {
+      throw new FastSerializerProtocolError(
+        "MALFORMED_PARAMETER",
+        "fast-serializer fixed-width field type must not declare a width",
+        0,
+      );
+    }
+    parts.push(Buffer.concat([
+      Buffer.from([typeCode, name.byteLength]),
+      name,
+    ]));
+  }
+  return Buffer.concat(parts);
 }

--- a/test/fast-serializer.test.ts
+++ b/test/fast-serializer.test.ts
@@ -12,6 +12,10 @@ import {
   decodeFastSerializerParameterAnnouncement,
   decodeFastSerializerRecord,
   decodeFastSerializerRecords,
+  encodeFastSerializerItem,
+  encodeFastSerializerParameterAnnouncement,
+  encodeFastSerializerRecord,
+  encodeFastSerializerRecords,
   fastSerializerTypeName,
 } from "../src/protocol/fast-serializer.js";
 
@@ -80,6 +84,40 @@ test("rejects malformed, truncated, and over-budget items", () => {
   assert.throws(
     () => decodeFastSerializerItems(Buffer.concat([valid, valid]), { maxItems: 1 }),
     /item count exceeds/u,
+  );
+});
+
+test("encodes exact self-closing items and snapshots caller bytes", () => {
+  const value = Buffer.from("payload");
+  const encoded = encodeFastSerializerItem(
+    FAST_SERIALIZER_PARAMETER_ITEM_ID,
+    value,
+  );
+  value.fill(0);
+
+  assert.deepEqual(
+    encoded,
+    item(FAST_SERIALIZER_PARAMETER_ITEM_ID, Buffer.from("payload")),
+  );
+  assert.equal(decodeFastSerializerItem(encoded).data.toString(), "payload");
+});
+
+test("rejects item identifiers and values outside the wire grammar", () => {
+  assert.throws(
+    () => encodeFastSerializerItem(-1, Buffer.alloc(0)),
+    (error: unknown) =>
+      error instanceof FastSerializerProtocolError &&
+      error.code === "INVALID_ARGUMENT",
+  );
+  assert.throws(
+    () => encodeFastSerializerItem(0x1_0000, Buffer.alloc(0)),
+    /identifier/u,
+  );
+  assert.throws(
+    () => encodeFastSerializerItem(1, Buffer.alloc(0x1_0000)),
+    (error: unknown) =>
+      error instanceof FastSerializerProtocolError &&
+      error.code === "ITEM_LIMIT_EXCEEDED",
   );
 });
 
@@ -182,6 +220,79 @@ test("fails closed on unsupported, malformed, empty, and truncated records", () 
   );
 });
 
+test("encodes every established record framing rule as one strict stream", () => {
+  const inputs = [
+    {
+      tag: FastSerializerRecordTag.Descriptor,
+      value: Buffer.from("\\TYPE=Z_NEUTRAL", "ascii"),
+    },
+    {
+      tag: FastSerializerRecordTag.Character,
+      value: Buffer.from("ABC", "ascii"),
+    },
+    {
+      tag: FastSerializerRecordTag.Int4,
+      value: Buffer.from([0x00, 0x01, 0x00, 0x00]),
+    },
+    {
+      tag: FastSerializerRecordTag.Padded,
+      value: Buffer.from("AB", "utf16le"),
+    },
+    {
+      tag: FastSerializerRecordTag.String,
+      value: Buffer.from("open-rfc", "utf8"),
+    },
+    { tag: FastSerializerRecordTag.End, value: Buffer.alloc(0) },
+  ] as const;
+  const encoded = encodeFastSerializerRecords(inputs);
+
+  assert.deepEqual(
+    encoded,
+    Buffer.concat([
+      descriptor("Z_NEUTRAL"),
+      Buffer.from([FastSerializerRecordTag.Character, 3, 0x80, 0x41, 0x42, 0x43]),
+      Buffer.from([FastSerializerRecordTag.Int4, 0x00, 0x01, 0x00, 0x00]),
+      Buffer.from([FastSerializerRecordTag.Padded, 0x00, 0x04, 0x41, 0x00, 0x42, 0x00]),
+      Buffer.from([
+        FastSerializerRecordTag.String,
+        0x08, 0xc0, 0x08, 0x00,
+        ...Buffer.from("open-rfc"),
+      ]),
+      Buffer.from([FastSerializerRecordTag.End]),
+    ]),
+  );
+  assert.deepEqual(
+    decodeFastSerializerRecords(encoded).map(({ tag, value }) => ({ tag, value })),
+    inputs,
+  );
+});
+
+test("rejects unrepresentable record values rather than truncating them", () => {
+  const rejected: ReadonlyArray<readonly [FastSerializerRecordTag, Buffer]> = [
+    [FastSerializerRecordTag.Character, Buffer.alloc(0)],
+    [FastSerializerRecordTag.Character, Buffer.alloc(256)],
+    [FastSerializerRecordTag.Descriptor, Buffer.alloc(256)],
+    [FastSerializerRecordTag.Int4, Buffer.alloc(3)],
+    [FastSerializerRecordTag.Padded, Buffer.alloc(0x1_0000)],
+    [FastSerializerRecordTag.String, Buffer.alloc(0x4000)],
+    [FastSerializerRecordTag.End, Buffer.of(1)],
+  ];
+  for (const [tag, value] of rejected) {
+    assert.throws(
+      () => encodeFastSerializerRecord(tag, value),
+      (error: unknown) =>
+        error instanceof FastSerializerProtocolError &&
+        error.code === "MALFORMED_RECORD",
+    );
+  }
+  assert.throws(
+    () => encodeFastSerializerRecord(0x99 as FastSerializerRecordTag, Buffer.of(1)),
+    (error: unknown) =>
+      error instanceof FastSerializerProtocolError &&
+      error.code === "UNSUPPORTED_RECORD_TAG",
+  );
+});
+
 test("decodes a synthetic field-description list with both width conventions", () => {
   const encoded = Buffer.concat([
     Buffer.from([0x44, 4]),
@@ -236,6 +347,77 @@ test("recognizes generated descriptors and rejects unknown field grammars", () =
   assert.throws(
     () => decodeFastSerializerParameterAnnouncement(malformedName),
     /plain protocol identifier/u,
+  );
+});
+
+test("encodes and decodes exact parameter announcements", () => {
+  const fields = [
+    { typeCode: FastSerializerTypeCode.Int4, name: "NUM" },
+    {
+      typeCode: FastSerializerTypeCode.Character,
+      width: 20,
+      name: "TEXT",
+    },
+    { typeCode: FastSerializerTypeCode.Raw, width: 3, name: "RAW" },
+    { typeCode: FastSerializerTypeCode.String, name: "DYNTXT" },
+  ] as const;
+  const encoded = encodeFastSerializerParameterAnnouncement({
+    typeName: "Z_NEUTRAL",
+    fields,
+  });
+
+  assert.deepEqual(
+    decodeFastSerializerParameterAnnouncement(encoded),
+    {
+      typeName: "Z_NEUTRAL",
+      generated: false,
+      fields,
+      offset: 0,
+      bytesConsumed: encoded.byteLength,
+    },
+  );
+});
+
+test("rejects ambiguous or unrepresentable parameter announcements", () => {
+  assert.throws(
+    () => encodeFastSerializerParameterAnnouncement({
+      typeName: "bad-name",
+      fields: [],
+    }),
+    /type name/u,
+  );
+  assert.throws(
+    () => encodeFastSerializerParameterAnnouncement({
+      typeName: "Z_TYPE",
+      fields: [{ typeCode: FastSerializerTypeCode.Character, name: "TEXT" }],
+    }),
+    /width/u,
+  );
+  assert.throws(
+    () => encodeFastSerializerParameterAnnouncement({
+      typeName: "Z_TYPE",
+      fields: [{ typeCode: FastSerializerTypeCode.Int4, width: 4, name: "NUM" }],
+    }),
+    /must not declare a width/u,
+  );
+  assert.throws(
+    () => encodeFastSerializerParameterAnnouncement({
+      typeName: "Z_TYPE",
+      fields: [{ typeCode: 0xff as FastSerializerTypeCode, name: "FIELD" }],
+    }),
+    (error: unknown) =>
+      error instanceof FastSerializerProtocolError &&
+      error.code === "UNSUPPORTED_TYPE_CODE",
+  );
+  assert.throws(
+    () => encodeFastSerializerParameterAnnouncement({
+      typeName: "Z_TYPE",
+      fields: Array.from({ length: 256 }, (_, index) => ({
+        typeCode: FastSerializerTypeCode.Int4,
+        name: `F${index}`,
+      })),
+    }),
+    /field count/u,
   );
 });
 


### PR DESCRIPTION
## Goal

Add the bounded production half of the internal fast-serializer foundation without widening the public package API or claiming end-to-end fast RFC support.

## Content

- encode exact self-closing transport items
- encode descriptor, character, INT4, padded, STRING, and end records
- encode bounded record streams and strict parameter field announcements
- reject unsupported tags, ambiguous widths, invalid names, and values that cannot fit their wire lengths instead of truncating them
- snapshot caller-owned byte values before producing output
- update the internal declaration snapshot and support-boundary documentation
- retain the existing Apache-2.0 open-rfc-go attribution at commit 92d5d8f6e0a08ff7ac1580f461585cbde2a56939 and describe the adapted/new encoder portions precisely

## Research and licensing

The overlapping character, descriptor, INT4, padded, and end encodings are byte-for-byte identical to open-rfc-go at the pinned Apache-2.0 revision. STRING, item, stream, and parameter-announcement production are strict TypeScript additions built from the already-decoded grammar. Tests use neutral synthetic values; no upstream capture fixture or private live output is redistributed.

## Validation

- npm test — 934 passed
- npm run lint
- npm run test:surface — 20 passed
- npm run docs:build — strict build passed
- upstream go test ./internal/fastser
- exact cross-language parity check for every encoder form shared with upstream

No fresh live-system result is claimed: these primitives are deliberately still internal and are not yet wired into a client or registered-server route. The README and roadmap keep compression production, complete parameter graphs, version negotiation, and end-to-end fast RFC support explicitly unsupported.