### PR TITLE
feat: support bounded RFC callbacks and wrapped XSTRINGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,12 +230,18 @@ npm record identify the released source and package.
   `passwd`, and treat the ticket as a credential. The target system must trust
   the ticket issuer. This path is protocol- and socket-tested offline but is not
   part of the live-qualified beta support contract yet.
+- Server-initiated RFC calls made with ABAP `DESTINATION 'BACK'` are an
+  implemented preview for classic client calls. Configure raw synchronous
+  handlers through `clientOptions.callbacks`; unknown functions receive
+  `FU_NOT_FOUND`, malformed callback traffic retires the session, and one outer
+  call is limited to 64 callbacks. This path is protocol- and scripted-socket
+  tested but has not been live-qualified by this TypeScript implementation.
 - WebSocket RFC business calls, Cloud Connector principal propagation, SNC,
   and X.509 are not supported and fail closed before business I/O when their
   required provider or authentication capability is absent.
 - SNC, other SSO mechanisms, X.509, non-Unicode/MDMP partners, registered server
-  mode, callbacks from ABAP, Throughput, tRFC, qRFC, bgRFC, basXML, compression,
-  and complete NW RFC SDK parity are not supported.
+  mode, Throughput, tRFC, qRFC, bgRFC, basXML, compression, and complete NW RFC
+  SDK parity are not supported.
 
 The package summary is intentionally narrow: unknown or unavailable provider
 capabilities fail before business I/O rather than silently disappearing, while

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -55,9 +55,13 @@ contributors:
 - `src/protocol/fast-serializer.ts`
 - `src/protocol/logon-ticket.ts`
 - `src/protocol/cpic.ts`
+- `src/protocol/rfc-callback.ts`
+- `src/values/classic-xrfc.ts`
+- `src/values/recursive-xrfc.ts`
+- `src/values/recursive-classic-xrfc.ts`
 
-They use the bounded fast-serializer work in `open-rfc-go` at
-commit `92d5d8f6e0a08ff7ac1580f461585cbde2a56939` as their implementation basis,
+They use Apache-licensed interoperability work in `open-rfc-go` at commit
+`92d5d8f6e0a08ff7ac1580f461585cbde2a56939` as an implementation basis,
 specifically these upstream files:
 
 - `internal/fastser/lz4.go`
@@ -66,6 +70,12 @@ specifically these upstream files:
 - `internal/fastser/fields.go`
 - `internal/cpic/ticket.go`
 - `internal/cpic/logon.go`
+- `internal/rfcserver/request.go`
+- `internal/rfcserver/response.go`
+- `internal/client/session.go`
+- `rfc/callback.go`
+- `internal/xrfc/classic_xrfc.go`
+- `internal/xrfc/recursive_xrfc_codec.go`
 
 The pinned upstream project carries this notice:
 
@@ -101,6 +111,19 @@ percent escapes and non-Base64 text, imposes a fixed input bound, makes password
 and ticket credentials mutually exclusive in its types and runtime validation,
 clears temporary credential bytes, and keeps tickets out of inspected and JSON
 route plans. No upstream capture or ticket value is redistributed.
+
+The callback adaptation covers the upstream established-session CUT
+request/response grammar and same-conversation callback loop. The TypeScript
+API exposes raw owned values to synchronous handlers, bounds handlers and
+callbacks to 64 per outer call, returns `FU_NOT_FOUND` for unknown functions,
+strictly validates field order and framing, and retires the connection on
+malformed or uncertain state. The scripted callback fixtures were authored for
+this project from synthetic values; no upstream capture is redistributed.
+
+The xRFC adaptation accepts SAP's MIME-style Base64 line wrapping for XSTRING
+cells. The TypeScript decoders remove only CR and LF before canonical Base64
+validation, retain the existing decoded and aggregate byte limits, and continue
+to reject spaces and all other non-canonical text.
 
 The public repository and npm package include a copy of the Apache License,
 Version 2.0 in their root `LICENSE` file. Unless required by applicable law or

--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -43,7 +43,7 @@
     "sha256": "3ced4556246b40fe4de22316ab1da7b6ae65ea0183a6a1d62e59fe08d293a041"
   },
   "subpathExportManifests": [],
-  "declarationCount": 69,
+  "declarationCount": 70,
   "declarations": [
     {
       "path": "dist/src/client/classic-invocation.d.ts",
@@ -52,8 +52,8 @@
     },
     {
       "path": "dist/src/client/direct-cpic-session.d.ts",
-      "bytes": 9672,
-      "sha256": "c86ab8c611af66b2d3178c3384c9439da9f8616421ad283fe082a167de5e1525"
+      "bytes": 9899,
+      "sha256": "2ef89cd701de5c1fad55bb88e6acdb888d183fd1bbdf2d7a4d0ee18720d762d8"
     },
     {
       "path": "dist/src/client/rfc-errors.d.ts",
@@ -67,8 +67,8 @@
     },
     {
       "path": "dist/src/compat/compatibility-owner-route.d.ts",
-      "bytes": 764,
-      "sha256": "39e75eeb00a0319b86af8b4b476c62462227e4aa0fd782dcbbbcf81d04705b23"
+      "bytes": 840,
+      "sha256": "4185e639c56d395aa81598736e85558d6a7e68b0587bb0b4af7f6bdc27d460cd"
     },
     {
       "path": "dist/src/compat/connection-parameters.d.ts",
@@ -107,13 +107,13 @@
     },
     {
       "path": "dist/src/compat/node-rfc-client.d.ts",
-      "bytes": 5298,
-      "sha256": "f837a35cd58020de51e4db07a67062bd6ee5e2da9821a44f6347ae135c45f0bf"
+      "bytes": 5768,
+      "sha256": "0b7491cdb73cef8bec0799b319fd47c5b52d4f27f390fbba5e843e42f9931b0f"
     },
     {
       "path": "dist/src/compat/node-rfc-library.d.ts",
-      "bytes": 2446,
-      "sha256": "dbfa61975d327865374e68b80883efd16e12516cf532bbb7fb695e67097fa6cc"
+      "bytes": 2649,
+      "sha256": "806dc59eb024cf57292eb2243a99ef3f5aea30c940fb506eeb769250cd76e3d5"
     },
     {
       "path": "dist/src/compat/node-rfc-pool.d.ts",
@@ -157,8 +157,8 @@
     },
     {
       "path": "dist/src/destination/direct-destination-owner.d.ts",
-      "bytes": 9797,
-      "sha256": "38bf9a2db3415a413c836ba0d155ae8e56da2546a9dabc1304931636062fb6c8"
+      "bytes": 9915,
+      "sha256": "c5a90900ad1b38a4a921d9fe87a97d12fa0b9434dc502389523657d222bd2325"
     },
     {
       "path": "dist/src/destination/runtime.d.ts",
@@ -172,8 +172,8 @@
     },
     {
       "path": "dist/src/index.d.ts",
-      "bytes": 1955,
-      "sha256": "ef3121a5c90b071c001c5c38105d8e0b91e1ef3284faf3d391fc0928fb2137b8"
+      "bytes": 2210,
+      "sha256": "221fa7c289aca13617f5b1d00379246fb73643ac0d91d4ce7bd5b641d9aa6327"
     },
     {
       "path": "dist/src/lifecycle/session-context-runtime.d.ts",
@@ -286,6 +286,11 @@
       "sha256": "bd786e2b3f9bfe294abea23af6e6585baa60f51003f34653764235e479e07b1b"
     },
     {
+      "path": "dist/src/protocol/rfc-callback.d.ts",
+      "bytes": 2831,
+      "sha256": "7f2b9ef32babd955dd4738588b87f33ffa5e2a06149d0cbd25c9418e16e288e2"
+    },
+    {
       "path": "dist/src/protocol/rfc-error-envelope.d.ts",
       "bytes": 4595,
       "sha256": "bf4847844d175b1e77c5a190c7f0a0fc27579f2071a1b04173436f697fa25a0d"
@@ -391,5 +396,5 @@
       "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "b1e58fa9cd356f2b8921e68c47897a9719df6c364e6495413685ead75c2a074a"
+  "aggregateSha256": "dcc8824b1cf51b6d63a4cf2fceab74dcf7481d6e1978b575ae488b654c92e473"
 }

--- a/docs_page/api.md
+++ b/docs_page/api.md
@@ -71,6 +71,7 @@ return them from a diagnostics endpoint.
 | `clientOptions.logLevel` | Accepted non-negative compatibility log level. |
 | `clientOptions.diagnostics` | Optional bounded structured diagnostic emitter. Never emit RFC inputs, outputs, or credentials from application wrappers. |
 | `clientOptions.recursiveSerializerPolicy` | Advanced open-rfc extension for recursive (nested table or structure) sends. Shape: `{ profile, observation: { defaultSerializer, basxmlDisabledSerializer } }`, where `profile` is `"abap-7.50"` or `"abap-7.58"`, `defaultSerializer` is `"classic-xrfc"`, `"basxml"` or `"unsupported"`, and `basxmlDisabledSerializer` is `"classic-xrfc"` or `"unsupported"`. General beta consumers must omit it unless the exact artifact's published support record supports the selected partner and value graph; omitted recursive sends fail closed. |
+| `clientOptions.callbacks` | Preview handlers for server-initiated `DESTINATION 'BACK'` calls, keyed by exact RFM name. A handler receives owned raw classic-RFC values plus `{ callbackIndex, signal }` and must synchronously return `{ exports?, tables? }`. Unknown callback RFMs receive `FU_NOT_FOUND`; malformed, unconfigured, asynchronous, or excessive callback activity fails closed. |
 
 `cancel()` signals active calls and resolves after signaling; await the original
 call promise or callback for its terminal outcome. A timeout or cancellation is
@@ -82,6 +83,26 @@ recursive serializer policy. Direct observation alone is not enough. Do not
 copy a policy from another SAP release, function, or value graph. Unless the
 exact release support record explicitly supports your
 graph, omit the option and keep the fail-closed result.
+
+Callback handlers execute while the outer call owns its physical session. Do
+not call the same client or await work from a handler. Interpret and construct
+raw parameter bytes using the callback RFM's exact ABAP metadata; this preview
+does not project callback values into normal JavaScript RFC objects. At most 64
+callbacks are serviced during one outer call. Callback request and response
+bytes must not be logged.
+
+```ts
+const client = new Client(connectionParameters, {
+  callbacks: {
+    STFC_CONNECTION(request) {
+      const input = request.imports.find(({ name }) => name === "REQUTEXT");
+      return input === undefined
+        ? {}
+        : { exports: [{ name: "ECHOTEXT", value: input.value }] };
+    },
+  },
+});
+```
 
 ## Connection parameters
 
@@ -226,8 +247,9 @@ supported way to abort and join active connection operations.
 `connectionInfo` returns an `Error` value after close and otherwise contains
 operationally sensitive route and user identity. The optional constructor
 logger has a `log(type, ...args)` method; open-rfc sends it only fixed lifecycle
-messages. The only current `RFCClient` configuration field is the same advanced
-`recursiveSerializerPolicy` described for `Client` above.
+messages. `RFCClient` configuration accepts the same advanced
+`recursiveSerializerPolicy` and raw synchronous `callbacks` preview described
+for `Client` above.
 
 `execute()` accepts direction-specific `import`, `changing`, and `table`
 buckets. A parameter may appear in only one bucket. Validation is enabled by
@@ -320,7 +342,7 @@ unless metadata says otherwise.
 | NUMC | Digit-only `string`; input is width-checked and left-zero-padded. |
 | DATE, TIME | Canonical digit strings; an initial ABAP value is `""`. |
 | STRING | `string`. |
-| BYTE, XSTRING | `Uint8Array` / `Buffer`. |
+| BYTE, XSTRING | `Uint8Array` / `Buffer`. Inbound xRFC XSTRING accepts canonical Base64 with SAP MIME-style CR/LF wrapping; spaces and other non-canonical text remain invalid. |
 | INT1, INT2, INT4 | `number`. |
 | INT8 | Modern API: `bigint`. Classic API: safe `number` by default, or explicit bigint/string mode. |
 | BCD/PACKED, DECF16/34 | Precision-preserving decimal `string` by default; classic callers may select number or a converter. |

--- a/docs_page/node-rfc.md
+++ b/docs_page/node-rfc.md
@@ -65,8 +65,10 @@ Before replacing an existing installation:
 2. Keep `Client` and `Pool` imports, but remove or redesign uses of `Server`,
    `Throughput`, `noderfc_binding`, `reloadIniFile`, SDK-global/INI
    configuration, SNC, SSO modes other than the documented MYSAPSSO2 preview,
-   X.509, registered server mode, callbacks from ABAP, tRFC, qRFC, and bgRFC.
-   They are not supplied by this beta.
+   X.509, registered server mode, tRFC, qRFC, and bgRFC. They are not supplied
+   by this beta. Client-side callbacks from ABAP are available only through the
+   raw, synchronous `clientOptions.callbacks` preview; they are not a drop-in
+   replacement for native callback handlers.
 3. Use only the supported direct application-server route; message-server and
    SAProuter code is an unsupported preview, not a migration target.
 4. Treat `call()` and the metadata methods as Promise-only, `invoke()` as the
@@ -315,6 +317,7 @@ If release fails, still attempt `closeAll()` and preserve both failures.
 |---|---|
 | `Client` / `Pool` | Promise and callback lifecycle, invoke/call, ping, cancellation, timeout, reset, and bounded pooling are part of the supported direct-route boundary. |
 | Values | Classic scalar, flat structure, structured table, STRING/XSTRING, exact decimal strings, and configurable INT8 output are supported within documented limits. Project tests exercise representative values; they do not cover every value on both selected SAP releases. |
+| RFC callbacks | Client-side `DESTINATION 'BACK'` is a raw synchronous preview, bounded to 64 callbacks per outer call and not yet live-qualified by this TypeScript implementation. Registered server mode remains unsupported. |
 | Unsupported options | Must fail before I/O; an option is never intentionally ignored merely to appear compatible. |
 | Native SDK globals | `Server`, `Throughput`, `noderfc_binding`, INI reload, and SDK-specific global configuration are not supplied. |
 

--- a/docs_page/roadmap.md
+++ b/docs_page/roadmap.md
@@ -314,7 +314,7 @@ Document which server, transactional, security, serializer, legacy-encoding, and
   - Stable unsupported-capability matrix
   - Fail-closed configuration review
 - **Acceptance criteria:**
-  - Server/callback mode, tRFC/qRFC/bgRFC, Throughput, security modes, serializers, and legacy encodings each have an explicit disposition.
+  - Registered server mode, client-side callback preview, tRFC/qRFC/bgRFC, Throughput, security modes, serializers, and legacy encodings each have an explicit disposition.
   - Conditional items not selected for 1.0 are documented as unsupported rather than silently omitted.
   - Version 1.0 does not claim unbounded SDK parity.
 
@@ -1226,4 +1226,4 @@ Publish through the established GitHub, npm, and Pages pipeline, verify exact by
 
 ## What 1.0 does not imply
 
-Version 1.0 will stabilize the reviewed support boundary; it will not imply complete SAP NW RFC SDK parity. Server/callback mode, tRFC, qRFC, bgRFC, Throughput, SNC/X.509, non-Unicode/MDMP, basXML, WebSocket RFC, Cloud Connector principal propagation, message-server routing, and SAProuter remain unsupported unless their conditional roadmap items are explicitly promoted and pass their complete acceptance evidence.
+Version 1.0 will stabilize the reviewed support boundary; it will not imply complete SAP NW RFC SDK parity. Registered server mode, tRFC, qRFC, bgRFC, Throughput, SNC/X.509, non-Unicode/MDMP, basXML, WebSocket RFC, Cloud Connector principal propagation, message-server routing, and SAProuter remain unsupported unless their conditional roadmap items are explicitly promoted and pass their complete acceptance evidence. The current raw client-side callback preview is not a registered-server implementation and must pass its own live acceptance evidence before becoming a stable claim.

--- a/docs_page/safety.md
+++ b/docs_page/safety.md
@@ -28,6 +28,10 @@
   per-phase bound before the RFC handshake begins.
 - Classify authorization or environment failure separately from protocol
   incompatibility.
+- Treat `DESTINATION 'BACK'` handlers as synchronous code inside the active
+  outer exchange. Do not re-enter the same client, return a Promise, retain raw
+  buffers unnecessarily, or log callback inputs and outputs. Unknown functions
+  receive `FU_NOT_FOUND`; malformed or excessive callbacks retire the session.
 
 ## Uncertain send
 

--- a/docs_page/status.md
+++ b/docs_page/status.md
@@ -63,6 +63,13 @@ parameter-to-CPIC path is covered by offline and scripted-socket tests, but no
 disposable ticket was available for qualification on both documented live SAP
 systems. Password authentication therefore remains the current beta claim.
 
+Client-side `DESTINATION 'BACK'` callbacks are another implemented preview.
+The bounded same-session callback loop, success response, `FU_NOT_FOUND`
+response, and fail-closed unconfigured path are covered by protocol and
+scripted-socket tests. The TypeScript implementation has not yet been exercised
+against the callback RFMs on both documented live SAP systems, so callbacks are
+not part of the live-qualified beta claim.
+
 ## Public source and license
 
 The source and npm package are distributed under Apache-2.0. The repository

--- a/docs_page/troubleshooting.md
+++ b/docs_page/troubleshooting.md
@@ -13,6 +13,8 @@
 | `RFC_NO_AUTHORITY` | Authenticated but missing RFM/metadata authorization | Compare the exact `S_RFC` allowlist; do not grant a wildcard. |
 | Unknown RFM or missing metadata | Release/fixture mismatch or metadata denial | Verify the RFM is active and remote-enabled, then test metadata separately. |
 | Value/type rejection | Metadata or JavaScript representation | Compare casing, direction, length, decimals, and nested shape. |
+| Callback receives `FU_NOT_FOUND` | No exact handler name is configured | Match the ABAP callback RFM name exactly; do not add a catch-all handler. |
+| Callback closes the session | Unconfigured callback, malformed framing, asynchronous handler, or callback limit | Verify `clientOptions.callbacks`, keep handlers synchronous, and inspect only redacted structural diagnostics. |
 | Timeout/cancel after send | Ambiguous business outcome | Retire the connection and reconcile; never replay automatically. |
 
 ## Connection fails before logon

--- a/src/client/direct-cpic-session.ts
+++ b/src/client/direct-cpic-session.ts
@@ -47,6 +47,17 @@ import {
   snapshotUint8Array,
 } from "../protocol/bytes.js";
 import {
+  DEFAULT_MAX_RFC_CALLBACKS_PER_CALL,
+  decodeCpicRfcCallbackRequest,
+  encodeCpicRfcCallbackException,
+  encodeCpicRfcCallbackResponse,
+  frameCpicRfcCallbackResponse,
+  isCpicRfcCallbackRequest,
+  snapshotRfcCallbackHandlers,
+  type RfcCallbackHandler,
+  type RfcCallbackHandlers,
+} from "../protocol/rfc-callback.js";
+import {
   RfcConnectionDisposition,
   RfcCoreError,
   RfcFailureCategory,
@@ -155,6 +166,8 @@ export interface DirectCpicSessionOptions {
    * Flat/classic calls do not require this policy.
    */
   readonly recursiveSerializerDecisionProvider?: RecursiveSerializerDecisionProvider;
+  /** Raw synchronous handlers for server-initiated DESTINATION 'BACK' calls. */
+  readonly callbacks?: RfcCallbackHandlers;
 }
 
 /**
@@ -661,6 +674,7 @@ function snapshotSessionOptions(
     cpicStreaming: options.cpicStreaming,
     recursiveSerializerDecisionProvider:
       options.recursiveSerializerDecisionProvider,
+    callbacks: options.callbacks,
   });
   validateSessionOptions(snapshot);
   return snapshot;
@@ -677,6 +691,7 @@ export class DirectCpicSession {
   readonly #cpicStreaming: "disabled" | "enabled";
   readonly #recursiveSerializerDecisionProvider:
     RecursiveSerializerDecisionProvider | undefined;
+  readonly #callbacks: ReadonlyMap<string, RfcCallbackHandler> | undefined;
   #conversationId: Buffer;
   #connectionIndex: number;
   #busy = false;
@@ -701,6 +716,7 @@ export class DirectCpicSession {
     cpicStreaming: "disabled" | "enabled",
     recursiveSerializerDecisionProvider:
       RecursiveSerializerDecisionProvider | undefined,
+    callbacks: ReadonlyMap<string, RfcCallbackHandler> | undefined,
   ) {
     this.#transport = transport;
     this.#localAddress = localAddress;
@@ -713,6 +729,7 @@ export class DirectCpicSession {
     this.#cpicStreaming = cpicStreaming;
     this.#recursiveSerializerDecisionProvider =
       recursiveSerializerDecisionProvider;
+    this.#callbacks = callbacks;
     this.info = Object.freeze({
       localAddress,
       peerCodePage: gateway.codePage,
@@ -724,6 +741,10 @@ export class DirectCpicSession {
 
   static async open(options: DirectCpicSessionOptions): Promise<DirectCpicSession> {
     const sessionOptions = snapshotSessionOptions(options);
+    const callbacks = snapshotRfcCallbackHandlers(
+      sessionOptions.callbacks,
+      "direct CPIC session callbacks",
+    );
     const cpicStreaming = sessionOptions.cpicStreaming ?? "disabled";
     if (cpicStreaming !== "disabled" && cpicStreaming !== "enabled") {
       throw new RangeError("cpicStreaming must be disabled or enabled");
@@ -922,6 +943,7 @@ export class DirectCpicSession {
         programName,
         cpicStreaming,
         sessionOptions.recursiveSerializerDecisionProvider,
+        callbacks,
       );
     } catch (error) {
       await transport.close().catch(() => undefined);
@@ -1315,6 +1337,7 @@ export class DirectCpicSession {
         recursiveMetadata,
       ),
       signal,
+      true,
     );
     const decoded = await this.#decodeRegularResponse(response);
     return this.#decodeApplicationResult(() =>
@@ -1412,7 +1435,7 @@ export class DirectCpicSession {
     } catch (cause) {
       throw new DirectCpicPreWireError(cause);
     }
-    const response = await this.exchange(request, signal);
+    const response = await this.exchange(request, signal, true);
     const decoded = await this.#decodeRegularResponse(response);
     return this.#decodeApplicationResult(() =>
       decodeOwnedClassicRfcInvocationResult(
@@ -1543,8 +1566,46 @@ export class DirectCpicSession {
     return definition;
   }
 
-  async exchange(data: Uint8Array, signal?: AbortSignal): Promise<Buffer> {
-    return this.#exchange(data, signal);
+  async exchange(
+    data: Uint8Array,
+    signal?: AbortSignal,
+    allowCallbacks = false,
+  ): Promise<Buffer> {
+    return this.#exchange(data, signal, undefined, allowCallbacks);
+  }
+
+  #planOutgoingRequest(data: Uint8Array): readonly AppcOutgoingDataFragment[] {
+    if (!(data instanceof Uint8Array)) {
+      throw new TypeError("RFC request data must be a Uint8Array");
+    }
+    const requestByteLength = intrinsicUint8ArrayByteLength(data);
+    if (
+      requestByteLength >
+        DEFAULT_MAX_APPC_OUTGOING_MESSAGE_LENGTH +
+          APPC_FINAL_SAP_PARAMETER_LENGTH
+    ) {
+      throw new RangeError(
+        "RFC request exceeds the direct CPIC request envelope",
+      );
+    }
+    const request = snapshotUint8Array(
+      data,
+      "RFC request data",
+      requestByteLength,
+    );
+    const framing = inspectCpicRequestAppcFraming(request);
+    return planOutgoingAppcDataFragments(
+      {
+        conversationId: this.#conversationId,
+        communicationIndex: 0xffff,
+        connectionIndex: this.#connectionIndex,
+        applicationData: request.subarray(0, framing.applicationDataLength),
+        finalSapParameters: framing.finalSapParameterLength === 0
+          ? undefined
+          : request.subarray(framing.applicationDataLength),
+      },
+      { cpicStreaming: this.#cpicStreaming },
+    );
   }
 
   #assertExchangeAvailable(owner?: symbol): void {
@@ -1570,42 +1631,13 @@ export class DirectCpicSession {
     data: Uint8Array,
     signal?: AbortSignal,
     owner?: symbol,
+    allowCallbacks = false,
   ): Promise<Buffer> {
     if (this.#closed) throw new Error("direct CPIC session is closed");
     this.#assertExchangeAvailable(owner);
     let outgoingPlan: readonly AppcOutgoingDataFragment[];
     try {
-      if (!(data instanceof Uint8Array)) {
-        throw new TypeError("RFC request data must be a Uint8Array");
-      }
-      const requestByteLength = intrinsicUint8ArrayByteLength(data);
-      if (
-        requestByteLength >
-          DEFAULT_MAX_APPC_OUTGOING_MESSAGE_LENGTH +
-            APPC_FINAL_SAP_PARAMETER_LENGTH
-      ) {
-        throw new RangeError(
-          "RFC request exceeds the direct CPIC request envelope",
-        );
-      }
-      const request = snapshotUint8Array(
-        data,
-        "RFC request data",
-        requestByteLength,
-      );
-      const framing = inspectCpicRequestAppcFraming(request);
-      outgoingPlan = planOutgoingAppcDataFragments(
-        {
-          conversationId: this.#conversationId,
-          communicationIndex: 0xffff,
-          connectionIndex: this.#connectionIndex,
-          applicationData: request.subarray(0, framing.applicationDataLength),
-          finalSapParameters: framing.finalSapParameterLength === 0
-            ? undefined
-            : request.subarray(framing.applicationDataLength),
-        },
-        { cpicStreaming: this.#cpicStreaming },
-      );
+      outgoingPlan = this.#planOutgoingRequest(data);
     } catch (cause) {
       throw new RfcCoreError(createRfcFailure({
         category: RfcFailureCategory.Serialization,
@@ -1636,6 +1668,7 @@ export class DirectCpicSession {
       transmission = RfcTransmissionState.Complete;
       phase = RfcOperationPhase.Receive;
       let decoder: AppcConversationDecoder | undefined;
+      let callbackCount = 0;
       for (;;) {
         const payload = await this.#transport.receive({
           timeoutMs: this.#operationTimeoutMs,
@@ -1672,6 +1705,53 @@ export class DirectCpicSession {
             // pre-send boundary above.
             this.#transport.assertNoQueuedFrames();
             this.#setup.responseComplete();
+          }
+          if (isCpicRfcCallbackRequest(message.data)) {
+            if (!allowCallbacks || this.#callbacks === undefined) {
+              throw new Error(
+                "server sent an RFC callback but no callback handlers are configured",
+              );
+            }
+            callbackCount += 1;
+            if (callbackCount > DEFAULT_MAX_RFC_CALLBACKS_PER_CALL) {
+              throw new Error(
+                `server exceeded ${DEFAULT_MAX_RFC_CALLBACKS_PER_CALL} RFC callbacks in one call`,
+              );
+            }
+            const callbackRequest = decodeCpicRfcCallbackRequest(message.data);
+            const handler = this.#callbacks.get(callbackRequest.functionName);
+            let callbackResponse: Buffer;
+            if (handler === undefined) {
+              callbackResponse = encodeCpicRfcCallbackException("FU_NOT_FOUND");
+            } else {
+              const response = Reflect.apply(handler, undefined, [
+                callbackRequest,
+                Object.freeze({ callbackIndex: callbackCount, signal }),
+              ]) as ReturnType<typeof handler>;
+              if (
+                typeof response === "object" &&
+                response !== null &&
+                "then" in response &&
+                typeof (response as { readonly then?: unknown }).then === "function"
+              ) {
+                throw new TypeError("RFC callback handlers must return synchronously");
+              }
+              callbackResponse = encodeCpicRfcCallbackResponse(response);
+            }
+            outgoingPlan = this.#planOutgoingRequest(
+              frameCpicRfcCallbackResponse(callbackResponse),
+            );
+            phase = RfcOperationPhase.Send;
+            await writeOutgoingAppcDataPlan(
+              this.#transport,
+              this.#setup,
+              outgoingPlan,
+              signal,
+              this.#operationTimeoutMs,
+            );
+            phase = RfcOperationPhase.Receive;
+            decoder = undefined;
+            continue;
           }
           return message.data;
         }

--- a/src/compat/compatibility-owner-route.ts
+++ b/src/compat/compatibility-owner-route.ts
@@ -1,4 +1,7 @@
-import type { DirectDestinationSessionFactory } from
+import type {
+  DirectDestinationSessionFactory,
+  DirectDestinationSessionOptions,
+} from
   "../destination/direct-destination-owner.js";
 import { createProductionDirectDestinationSessionFactory } from
   "../destination/direct-destination-owner.js";
@@ -33,6 +36,7 @@ export interface CompatibilityOwnerRoute {
  */
 export function planCompatibilityOwnerRoute(
   parameters: RfcConnectionParameters,
+  session?: DirectDestinationSessionOptions,
 ): CompatibilityOwnerRoute {
   const plan = planConnectionRoute(parameters);
   if (plan.route.kind === "direct") {
@@ -55,6 +59,7 @@ export function planCompatibilityOwnerRoute(
         kind: "direct" as const,
         connection: normalizedDirectConnectionFromPlan(plan),
         sessionFactory: createProductionDirectDestinationSessionFactory({
+          ...session,
           transportFactory,
         }),
       });
@@ -67,6 +72,7 @@ export function planCompatibilityOwnerRoute(
         kind: "direct" as const,
         connection: normalizedDirectConnectionFromPlan(plan),
         sessionFactory: createProductionDirectDestinationSessionFactory({
+          ...session,
           transportFactory,
         }),
       });
@@ -93,6 +99,9 @@ export function planCompatibilityOwnerRoute(
   return Object.freeze({
     kind: "message-server" as const,
     connection: messageServerOwnerConnection(plan),
-    sessionFactory: createMessageServerDirectSessionFactory({ plan }),
+    sessionFactory: createMessageServerDirectSessionFactory({
+      plan,
+      ...(session === undefined ? {} : { directSession: session }),
+    }),
   });
 }

--- a/src/compat/node-rfc-client.ts
+++ b/src/compat/node-rfc-client.ts
@@ -25,6 +25,7 @@ import {
   type DirectDestinationApplicationLease,
   type DirectDestinationOwner,
   type DirectDestinationSessionFactory,
+  type DirectDestinationSessionOptions,
 } from "../destination/direct-destination-owner.js";
 import {
   createDeferredRfcDiagnosticReporter,
@@ -35,6 +36,10 @@ import {
 import type { RfcFunctionInterface } from "../metadata/rfc-function-interface.js";
 import type { RfcStructureDefinition } from "../metadata/rfc-structure-definition.js";
 import { NiTransportError } from "../transport/ni-socket.js";
+import {
+  snapshotRfcCallbackHandlers,
+  type RfcCallbackHandlers,
+} from "../protocol/rfc-callback.js";
 import { ConnectivitySocks5Error } from
   "../transport/connectivity-socks5-tunnel.js";
 import { SapRouterTransportError } from "../transport/saprouter-tunnel.js";
@@ -81,6 +86,8 @@ export interface RfcClientOptions {
   readonly diagnostics?: RfcDiagnosticEmitter;
   /** open-rfc extension: evidence-bound admission for recursive live sends. */
   readonly recursiveSerializerPolicy?: LiveRecursiveSerializerPolicy;
+  /** open-rfc preview: raw synchronous DESTINATION 'BACK' handlers by FM name. */
+  readonly callbacks?: RfcCallbackHandlers;
 }
 
 export interface RfcCallOptions {
@@ -350,6 +357,7 @@ const RFC_CLIENT_OPTION_NAMES = Object.freeze([
   "logLevel",
   "diagnostics",
   "recursiveSerializerPolicy",
+  "callbacks",
 ] as const);
 const RFC_CLIENT_OPTION_KEYS = new Set<string>(RFC_CLIENT_OPTION_NAMES);
 
@@ -393,6 +401,7 @@ export function snapshotRfcClientOptions(
     logLevel?: number;
     diagnostics?: RfcDiagnosticEmitter;
     recursiveSerializerPolicy?: LiveRecursiveSerializerPolicy;
+    callbacks?: RfcCallbackHandlers;
   } = {};
   for (const name of RFC_CLIENT_OPTION_NAMES) {
     const captured = ownDataValue(input, name, "clientOptions");
@@ -405,7 +414,8 @@ export function snapshotRfcClientOptions(
         name === "bcd" ||
         name === "int8Mode" ||
         name === "diagnostics" ||
-        name === "recursiveSerializerPolicy"
+        name === "recursiveSerializerPolicy" ||
+        name === "callbacks"
       ) &&
       captured.value === undefined
     ) continue;
@@ -419,9 +429,16 @@ export function snapshotRfcClientOptions(
           ? snapshotLiveRecursiveSerializerPolicy(
               captured.value as LiveRecursiveSerializerPolicy,
             )
-          : name === "int8Mode"
-            ? snapshotClassicInt8Mode(captured.value, "clientOptions.int8Mode")
-            : captured.value,
+          : name === "callbacks"
+            ? Object.freeze(Object.fromEntries(
+                snapshotRfcCallbackHandlers(
+                  captured.value as RfcCallbackHandlers,
+                  "clientOptions.callbacks",
+                )!,
+              ))
+            : name === "int8Mode"
+              ? snapshotClassicInt8Mode(captured.value, "clientOptions.int8Mode")
+              : captured.value,
       enumerable: true,
       configurable: false,
       writable: false,
@@ -460,6 +477,28 @@ export function snapshotRfcClientOptions(
     throw new RangeError("clientOptions.logLevel must be a non-negative integer");
   }
   return Object.freeze(snapshot);
+}
+
+/** Internal composition shared by archived Client and Pool owner creation. */
+export function directSessionOptionsFromRfcClientOptions(
+  options: RfcClientOptions | undefined,
+): DirectDestinationSessionOptions | undefined {
+  const recursiveSerializerPolicy = options?.recursiveSerializerPolicy;
+  const callbacks = options?.callbacks;
+  if (recursiveSerializerPolicy === undefined && callbacks === undefined) {
+    return undefined;
+  }
+  return Object.freeze({
+    ...(callbacks === undefined ? {} : { callbacks }),
+    ...(recursiveSerializerPolicy === undefined
+      ? {}
+      : {
+          recursiveSerializerDecisionProvider:
+            createLiveRecursiveSerializerDecisionProvider(
+              recursiveSerializerPolicy,
+            ),
+        }),
+  });
 }
 
 function notRequestedSet(options: RfcCallOptions): ReadonlySet<string> {
@@ -728,16 +767,18 @@ export class Client {
     }
     let normalized: NormalizedDirectConnection;
     let sessionFactory: DirectDestinationSessionFactory | undefined;
+    const session = directSessionOptionsFromRfcClientOptions(this.#clientOptions);
     try {
-      const route = planCompatibilityOwnerRoute(this.#connectionParameters);
+      const route = planCompatibilityOwnerRoute(
+        this.#connectionParameters,
+        session,
+      );
       normalized = route.connection;
       sessionFactory = route.sessionFactory;
     } catch (error) {
       this.#state = "closed";
       throw projectNodeRfcNormalizationError(error);
     }
-    const recursiveSerializerPolicy =
-      this.#clientOptions?.recursiveSerializerPolicy;
     let owner: DirectDestinationOwner;
     try {
       owner = createOwner({
@@ -772,16 +813,7 @@ export class Client {
         ...(this.#clientOptions?.diagnostics === undefined
           ? {}
           : { metadata: { diagnostics: this.#clientOptions.diagnostics } }),
-        ...(recursiveSerializerPolicy === undefined
-          ? {}
-          : {
-              session: {
-                recursiveSerializerDecisionProvider:
-                  createLiveRecursiveSerializerDecisionProvider(
-                    recursiveSerializerPolicy,
-                  ),
-              },
-            }),
+        ...(session === undefined ? {} : { session }),
       });
     } catch (error) {
       if (this.#state === "opening") this.#state = "closed";

--- a/src/compat/node-rfc-library.ts
+++ b/src/compat/node-rfc-library.ts
@@ -62,6 +62,10 @@ import {
   createConnectivitySocks5DirectCpicTransportFactory,
 } from "../transport/connectivity-socks5-ni.js";
 import { NiTransportError } from "../transport/ni-socket.js";
+import {
+  snapshotRfcCallbackHandlers,
+  type RfcCallbackHandlers,
+} from "../protocol/rfc-callback.js";
 
 export interface RFCInputParams {
   readonly import?: RfcObject;
@@ -76,6 +80,8 @@ export interface RFCLogger {
 export interface RFCClientConfiguration {
   /** open-rfc extension: evidence-bound admission for recursive live sends. */
   readonly recursiveSerializerPolicy?: LiveRecursiveSerializerPolicy;
+  /** open-rfc preview: raw synchronous DESTINATION 'BACK' handlers by FM name. */
+  readonly callbacks?: RfcCallbackHandlers;
 }
 
 function snapshotRFCClientConfiguration(
@@ -84,25 +90,49 @@ function snapshotRFCClientConfiguration(
   if (input === undefined) return undefined;
   plainRecord(input, "RFCClient configuration");
   for (const key of Reflect.ownKeys(input)) {
-    if (key !== "recursiveSerializerPolicy") {
+    if (key !== "recursiveSerializerPolicy" && key !== "callbacks") {
       throw new TypeError("unknown RFCClient configuration property");
     }
   }
-  const descriptor = Object.getOwnPropertyDescriptor(
+  const recursiveDescriptor = Object.getOwnPropertyDescriptor(
     input,
     "recursiveSerializerPolicy",
   );
-  if (descriptor === undefined) return Object.freeze({});
-  if (!("value" in descriptor)) {
+  const callbacksDescriptor = Object.getOwnPropertyDescriptor(input, "callbacks");
+  if (
+    recursiveDescriptor !== undefined &&
+    !("value" in recursiveDescriptor)
+  ) {
     throw new TypeError(
       "RFCClient configuration recursiveSerializerPolicy must be an own data property",
     );
   }
-  if (descriptor.value === undefined) return Object.freeze({});
+  if (
+    callbacksDescriptor !== undefined &&
+    !("value" in callbacksDescriptor)
+  ) {
+    throw new TypeError(
+      "RFCClient configuration callbacks must be an own data property",
+    );
+  }
+  const recursiveSerializerPolicy = recursiveDescriptor?.value === undefined
+    ? undefined
+    : snapshotLiveRecursiveSerializerPolicy(
+        recursiveDescriptor.value as LiveRecursiveSerializerPolicy,
+      );
+  const callbacks = callbacksDescriptor?.value === undefined
+    ? undefined
+    : Object.freeze(Object.fromEntries(
+        snapshotRfcCallbackHandlers(
+          callbacksDescriptor.value as RfcCallbackHandlers,
+          "RFCClient configuration callbacks",
+        )!,
+      ));
   return Object.freeze({
-    recursiveSerializerPolicy: snapshotLiveRecursiveSerializerPolicy(
-      descriptor.value as LiveRecursiveSerializerPolicy,
-    ),
+    ...(recursiveSerializerPolicy === undefined
+      ? {}
+      : { recursiveSerializerPolicy }),
+    ...(callbacks === undefined ? {} : { callbacks }),
   });
 }
 
@@ -900,18 +930,24 @@ export class RFCClient {
     const capturedConfiguration = snapshotRFCClientConfiguration(configuration);
     const recursiveSerializerPolicy =
       capturedConfiguration?.recursiveSerializerPolicy;
+    const callbacks = capturedConfiguration?.callbacks;
     const ownerFactory: RFCClientDestinationOwnerFactory =
-      recursiveSerializerPolicy === undefined
+      recursiveSerializerPolicy === undefined && callbacks === undefined
         ? productionOwnerFactory
         : (connection, context) => createProductionOwner({
             connection,
             applicationPool: MODERN_APPLICATION_POOL,
             session: Object.freeze({
               ...(context?.session ?? {}),
-              recursiveSerializerDecisionProvider:
-                createLiveRecursiveSerializerDecisionProvider(
-                  recursiveSerializerPolicy,
-                ),
+              ...(callbacks === undefined ? {} : { callbacks }),
+              ...(recursiveSerializerPolicy === undefined
+                ? {}
+                : {
+                    recursiveSerializerDecisionProvider:
+                      createLiveRecursiveSerializerDecisionProvider(
+                        recursiveSerializerPolicy,
+                      ),
+                  }),
             }),
           });
     bindRFCClientDestinationOwnerFactory(this, ownerFactory);

--- a/src/compat/node-rfc-pool.ts
+++ b/src/compat/node-rfc-pool.ts
@@ -21,6 +21,7 @@ import {
   pooledClientClaim,
   projectNodeRfcNormalizationError,
   projectNodeRfcPublicError,
+  directSessionOptionsFromRfcClientOptions,
   snapshotRfcClientOptions,
   type PooledClientClaim,
   type RfcClientOptions,
@@ -286,8 +287,14 @@ export class Pool {
     if (this.#owner !== undefined) return this.#owner;
     this.#requiredOpen();
     let route;
+    const session = directSessionOptionsFromRfcClientOptions(
+      this.#clientOptions,
+    );
     try {
-      route = planCompatibilityOwnerRoute(this.#connectionParameters);
+      route = planCompatibilityOwnerRoute(
+        this.#connectionParameters,
+        session,
+      );
     } catch (error) {
       throw projectNodeRfcNormalizationError(error);
     }
@@ -328,6 +335,7 @@ export class Pool {
       ...(this.#clientOptions?.diagnostics === undefined
         ? {}
         : { metadata: { diagnostics: this.#clientOptions.diagnostics } }),
+      ...(session === undefined ? {} : { session }),
     });
     this.#normalized = route.connection;
     this.#owner = owner;

--- a/src/destination/direct-destination-owner.ts
+++ b/src/destination/direct-destination-owner.ts
@@ -18,6 +18,10 @@ import type {
   ClassicRfcOutput,
 } from "../client/classic-invocation.js";
 import {
+  snapshotRfcCallbackHandlers,
+  type RfcCallbackHandlers,
+} from "../protocol/rfc-callback.js";
+import {
   RfcConnectionDisposition,
   RfcCoreError,
   RfcFailureCategory,
@@ -113,6 +117,7 @@ export interface DirectDestinationSessionOptions {
   readonly operationTimeoutMs?: number;
   readonly transportFactory?: DirectCpicTransportFactory;
   readonly recursiveSerializerDecisionProvider?: RecursiveSerializerDecisionProvider;
+  readonly callbacks?: RfcCallbackHandlers;
 }
 
 export interface DirectDestinationPoolOptions {
@@ -225,6 +230,7 @@ interface CanonicalSessionOptions {
   readonly operationTimeoutMs: number;
   readonly transportFactory?: DirectCpicTransportFactory;
   readonly recursiveSerializerDecisionProvider?: RecursiveSerializerDecisionProvider;
+  readonly callbacks?: RfcCallbackHandlers;
 }
 
 interface CanonicalPoolOptions {
@@ -549,6 +555,7 @@ function snapshotSessionOptions(
   const transportFactory = input?.transportFactory;
   const recursiveSerializerDecisionProvider =
     input?.recursiveSerializerDecisionProvider;
+  const callbacks = input?.callbacks;
   if (!/^[\x20-\x7e]{1,64}$/u.test(programName)) {
     throw new RangeError("session programName must contain 1..64 ASCII bytes");
   }
@@ -569,6 +576,15 @@ function snapshotSessionOptions(
       "session recursiveSerializerDecisionProvider must be a function",
     );
   }
+  // Validate and snapshot the table here; DirectCpicSession snapshots it again
+  // per generation so no caller-owned object survives an asynchronous open.
+  const callbackSnapshot = snapshotRfcCallbackHandlers(
+    callbacks,
+    "session callbacks",
+  );
+  const snapshottedCallbacks = callbackSnapshot === undefined
+    ? undefined
+    : Object.freeze(Object.fromEntries(callbackSnapshot));
   return Object.freeze({
     programName,
     ...(localAddress === undefined ? {} : { localAddress }),
@@ -583,6 +599,9 @@ function snapshotSessionOptions(
       : {
           recursiveSerializerDecisionProvider,
         }),
+    ...(snapshottedCallbacks === undefined
+      ? {}
+      : { callbacks: snapshottedCallbacks }),
   });
 }
 
@@ -689,6 +708,9 @@ function createProductionSessionFactory(
               recursiveSerializerDecisionProvider:
                 options.recursiveSerializerDecisionProvider,
             }),
+        ...(options.callbacks === undefined
+          ? {}
+          : { callbacks: options.callbacks }),
       }]) as DirectCpicSession;
       const logon = callable(session.logonAndPing, "session.logonAndPing");
       const close = callable(session.close, "session.close");

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,3 +87,13 @@ export {
   type RfcDiagnosticSink,
   type RfcDiagnosticState,
 } from "./diagnostics/structured-diagnostics.js";
+export {
+  type RfcCallbackContext,
+  type RfcCallbackHandler,
+  type RfcCallbackHandlers,
+  type RfcCallbackNamedValue,
+  type RfcCallbackRequest,
+  type RfcCallbackResponse,
+  type RfcCallbackTable,
+  type RfcCallbackXrfcParameter,
+} from "./protocol/rfc-callback.js";

--- a/src/protocol/rfc-callback.ts
+++ b/src/protocol/rfc-callback.ts
@@ -1,0 +1,547 @@
+import { types as nodeUtilTypes } from "node:util";
+
+import {
+  CpicTag,
+  DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH,
+  decodeCpicFieldChainPrefix,
+  encodeCpicFieldChain,
+  inspectCpicRequestAppcFraming,
+  type CpicField,
+  type CpicRequestAppcFraming,
+} from "./cpic.js";
+import {
+  intrinsicUint8ArrayByteLength,
+  intrinsicUint8ArrayView,
+  snapshotUint8Array,
+} from "./bytes.js";
+import { MAX_APPC_APPLICATION_DATA_FRAGMENT_LENGTH } from "./appc.js";
+import { assertUnicodeScalarText } from "../values/unicode-scalar.js";
+
+// Adapted and hardened for TypeScript from open-rfc-go's Apache-2.0
+// internal/rfcserver request/response codec and rfc/callback framing at commit
+// 92d5d8f6e0a08ff7ac1580f461585cbde2a56939.
+
+export const DEFAULT_MAX_RFC_CALLBACKS_PER_CALL = 64;
+
+export interface RfcCallbackNamedValue {
+  readonly name: string;
+  readonly value: Buffer;
+}
+
+export interface RfcCallbackTable {
+  readonly name: string;
+  readonly rowByteLength: number;
+  readonly rows: readonly Buffer[];
+}
+
+export interface RfcCallbackXrfcParameter {
+  readonly value: Buffer;
+  readonly chunkCount: number;
+}
+
+/** Raw classic-RFC values supplied by a server-initiated DESTINATION 'BACK' call. */
+export interface RfcCallbackRequest {
+  readonly functionName: string;
+  readonly kernelRelease: string;
+  readonly requestedOutputs: readonly string[];
+  readonly imports: readonly RfcCallbackNamedValue[];
+  readonly tables: readonly RfcCallbackTable[];
+  readonly xrfcParameters: readonly RfcCallbackXrfcParameter[];
+}
+
+/** Raw classic-RFC values returned to one server-initiated callback. */
+export interface RfcCallbackResponse {
+  readonly exports?: readonly RfcCallbackNamedValue[];
+  readonly tables?: readonly RfcCallbackTable[];
+}
+
+export interface RfcCallbackContext {
+  readonly callbackIndex: number;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * A synchronous callback handler. Keeping this boundary synchronous prevents a
+ * detached or re-entrant promise from outliving ownership of the RFC session.
+ */
+export type RfcCallbackHandler = (
+  request: RfcCallbackRequest,
+  context: RfcCallbackContext,
+) => RfcCallbackResponse;
+
+export type RfcCallbackHandlers = Readonly<Record<string, RfcCallbackHandler>>;
+
+const CUT_REQUEST_PREFIX = Buffer.from("05020000", "hex");
+const CUT_RESPONSE_PREFIX = Buffer.from("05000000", "hex");
+const CUT_PACKET_SENTINEL = Buffer.from("ffff", "hex");
+const MAXIMUM_RFC_PACKET_SIZE = 0x8500;
+
+function callbackName(value: string, path: string, maximum: number): string {
+  assertUnicodeScalarText(value, path);
+  if (
+    value.length < 1 ||
+    value.length > maximum ||
+    value.includes("\0") ||
+    /[\u0001-\u001f\u007f]/u.test(value)
+  ) {
+    throw new RangeError(
+      `${path} must contain 1..${maximum} Unicode scalar characters without controls`,
+    );
+  }
+  return value;
+}
+
+function decodeCallbackName(
+  value: Uint8Array,
+  path: string,
+  maximum: number,
+): string {
+  if ((intrinsicUint8ArrayByteLength(value) & 1) !== 0) {
+    throw new Error(`${path} must contain an even number of UTF-16LE bytes`);
+  }
+  const decoded = Buffer.from(
+    intrinsicUint8ArrayView(value, path),
+  ).toString("utf16le").replace(/[ \0]+$/u, "");
+  return callbackName(decoded, path, maximum);
+}
+
+function encodeCallbackName(
+  value: string,
+  path: string,
+  maximum: number,
+): Buffer {
+  return Buffer.from(callbackName(value, path, maximum), "utf16le");
+}
+
+function callbackUint32(value: number, path: string): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 0xffff_ffff) {
+    throw new RangeError(`${path} must be an unsigned 32-bit integer`);
+  }
+  return value;
+}
+
+function boundedCallbackSnapshot(
+  value: Uint8Array,
+  path: string,
+): Buffer {
+  if (!(value instanceof Uint8Array)) {
+    throw new TypeError(`${path} must be a Uint8Array`);
+  }
+  const byteLength = intrinsicUint8ArrayByteLength(value);
+  if (byteLength > DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH) {
+    throw new RangeError(
+      `${path} exceeds ${DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH} bytes`,
+    );
+  }
+  return snapshotUint8Array(value, path, byteLength);
+}
+
+function exactCallbackTrailer(
+  payload: Uint8Array,
+  prefixLength: number,
+  bytesConsumed: number,
+): void {
+  const trailerOffset = prefixLength + bytesConsumed;
+  if (
+    payload.byteLength - trailerOffset !== 2 ||
+    Buffer.from(payload.subarray(trailerOffset)).readUInt16BE(0) !== CpicTag.End
+  ) {
+    throw new Error("callback CUT request trailer is invalid");
+  }
+}
+
+/** True only for the established-session CUT request discriminator. */
+export function isCpicRfcCallbackRequest(payload: Uint8Array): boolean {
+  if (!(payload instanceof Uint8Array)) return false;
+  const view = intrinsicUint8ArrayView(payload, "callback CUT request");
+  return view.byteLength >= CUT_REQUEST_PREFIX.byteLength &&
+    Buffer.from(
+      view.buffer,
+      view.byteOffset,
+      CUT_REQUEST_PREFIX.byteLength,
+    ).equals(CUT_REQUEST_PREFIX);
+}
+
+/** Decode one bounded inbound CUT request for callback dispatch. */
+export function decodeCpicRfcCallbackRequest(
+  payload: Uint8Array,
+): RfcCallbackRequest {
+  if (!isCpicRfcCallbackRequest(payload)) {
+    throw new Error("callback CUT request prefix is invalid");
+  }
+  const snapshot = boundedCallbackSnapshot(payload, "callback CUT request");
+  try {
+    const decoded = decodeCpicFieldChainPrefix(
+      snapshot.subarray(CUT_REQUEST_PREFIX.byteLength),
+      CpicTag.ContextEnd,
+      CpicTag.End,
+    );
+    exactCallbackTrailer(
+      snapshot,
+      CUT_REQUEST_PREFIX.byteLength,
+      decoded.bytesConsumed,
+    );
+
+    let functionName: string | undefined;
+    let kernelRelease = "";
+    const requestedOutputs: string[] = [];
+    const imports: RfcCallbackNamedValue[] = [];
+    const tables: RfcCallbackTable[] = [];
+    const xrfcParameters: RfcCallbackXrfcParameter[] = [];
+    const names = new Set<string>();
+
+    for (let index = 0; index < decoded.fields.length; index += 1) {
+      const field = decoded.fields[index]!;
+      switch (field.tag) {
+        case CpicTag.Kernel:
+          if (kernelRelease.length !== 0) {
+            throw new Error("callback CUT request repeats its kernel release");
+          }
+          kernelRelease = decodeCallbackName(field.value, "callback kernel release", 16);
+          break;
+        case CpicTag.Function:
+          if (functionName !== undefined) {
+            throw new Error("callback CUT request repeats its function name");
+          }
+          functionName = decodeCallbackName(field.value, "callback function name", 40);
+          break;
+        case CpicTag.CallContext:
+          if (field.value.byteLength !== 0) {
+            throw new Error("callback call-context control must be empty");
+          }
+          break;
+        case CpicTag.RequestedOutput: {
+          const name = decodeCallbackName(
+            field.value,
+            "callback requested output name",
+            30,
+          );
+          if (requestedOutputs.includes(name)) {
+            throw new Error(`callback CUT request repeats requested output ${name}`);
+          }
+          requestedOutputs.push(name);
+          break;
+        }
+        case CpicTag.ParameterName: {
+          const valueField = decoded.fields[index + 1];
+          if (valueField?.tag !== CpicTag.ParameterValue) {
+            throw new Error("callback parameter name is not followed by its value");
+          }
+          const name = decodeCallbackName(field.value, "callback import name", 30);
+          if (names.has(name)) {
+            throw new Error(`callback CUT request repeats input parameter ${name}`);
+          }
+          names.add(name);
+          imports.push(Object.freeze({
+            name,
+            value: Buffer.from(valueField.value),
+          }));
+          index += 1;
+          break;
+        }
+        case CpicTag.TableName: {
+          const headerField = decoded.fields[index + 1];
+          if (headerField?.tag !== CpicTag.TableHeader || headerField.value.byteLength !== 8) {
+            throw new Error("callback table name is not followed by an eight-byte header");
+          }
+          const name = decodeCallbackName(field.value, "callback table name", 30);
+          if (names.has(name)) {
+            throw new Error(`callback CUT request repeats input parameter ${name}`);
+          }
+          names.add(name);
+          const rowByteLength = headerField.value.readUInt32BE(0);
+          const rowCount = headerField.value.readUInt32BE(4);
+          const rows: Buffer[] = [];
+          index += 2;
+          while (
+            rows.length < rowCount &&
+            (decoded.fields[index]?.tag === CpicTag.TableContent ||
+              decoded.fields[index]?.tag === CpicTag.TableCompr)
+          ) {
+            const row = decoded.fields[index]!.value;
+            if (row.byteLength === 0 || row.byteLength > rowByteLength) {
+              throw new Error(`callback table ${name} row ${rows.length} has invalid length`);
+            }
+            rows.push(Buffer.from(row));
+            index += 1;
+          }
+          if (rows.length !== rowCount) {
+            throw new Error(
+              `callback table ${name} declares ${rowCount} rows but found ${rows.length}`,
+            );
+          }
+          tables.push(Object.freeze({
+            name,
+            rowByteLength,
+            rows: Object.freeze(rows),
+          }));
+          index -= 1;
+          break;
+        }
+        case CpicTag.XRfcParameter: {
+          if (field.value.byteLength !== 0) {
+            throw new Error("callback xRFC boundary must be empty");
+          }
+          const chunks: Buffer[] = [];
+          let byteLength = 0;
+          index += 1;
+          while (decoded.fields[index]?.tag === CpicTag.XRfcData) {
+            const chunk = decoded.fields[index]!.value;
+            if (chunk.byteLength === 0) {
+              throw new Error("callback xRFC chunk must not be empty");
+            }
+            byteLength += chunk.byteLength;
+            if (
+              !Number.isSafeInteger(byteLength) ||
+              byteLength > DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH
+            ) {
+              throw new RangeError("callback xRFC parameter exceeds its byte limit");
+            }
+            chunks.push(Buffer.from(chunk));
+            index += 1;
+          }
+          const closing = decoded.fields[index];
+          if (
+            chunks.length === 0 ||
+            closing?.tag !== CpicTag.XRfcParameter ||
+            closing.value.byteLength !== 0
+          ) {
+            throw new Error("callback xRFC parameter lacks its closing boundary");
+          }
+          xrfcParameters.push(Object.freeze({
+            value: Buffer.concat(chunks, byteLength),
+            chunkCount: chunks.length,
+          }));
+          break;
+        }
+        case CpicTag.End:
+          break;
+        case CpicTag.ParameterValue:
+          throw new Error("callback parameter value has no preceding name");
+        case CpicTag.TableHeader:
+        case CpicTag.TableContent:
+        case CpicTag.TableCompr:
+          throw new Error("callback table record has no preceding table name");
+        case CpicTag.XRfcData:
+          throw new Error("callback xRFC data has no opening boundary");
+        default:
+          throw new Error(
+            `callback CUT request contains unsupported tag 0x${field.tag.toString(16).padStart(4, "0")}`,
+          );
+      }
+    }
+    if (functionName === undefined) {
+      throw new Error("callback CUT request lacks a function name");
+    }
+    return Object.freeze({
+      functionName,
+      kernelRelease,
+      requestedOutputs: Object.freeze(requestedOutputs),
+      imports: Object.freeze(imports),
+      tables: Object.freeze(tables),
+      xrfcParameters: Object.freeze(xrfcParameters),
+    });
+  } finally {
+    snapshot.fill(0);
+  }
+}
+
+function snapshotNamedValues(
+  values: readonly RfcCallbackNamedValue[] | undefined,
+  path: string,
+): readonly RfcCallbackNamedValue[] {
+  if (values === undefined) return Object.freeze([]);
+  if (!Array.isArray(values)) throw new TypeError(`${path} must be an array`);
+  const names = new Set<string>();
+  return Object.freeze(values.map((entry, index) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new TypeError(`${path}[${index}] must be an object`);
+    }
+    const name = callbackName(entry.name, `${path}[${index}].name`, 30);
+    if (names.has(name)) throw new Error(`${path} repeats ${name}`);
+    names.add(name);
+    return Object.freeze({
+      name,
+      value: boundedCallbackSnapshot(entry.value, `${path}[${index}].value`),
+    });
+  }));
+}
+
+function snapshotTables(
+  tables: readonly RfcCallbackTable[] | undefined,
+): readonly RfcCallbackTable[] {
+  if (tables === undefined) return Object.freeze([]);
+  if (!Array.isArray(tables)) {
+    throw new TypeError("callback response tables must be an array");
+  }
+  const names = new Set<string>();
+  return Object.freeze(tables.map((table, tableIndex) => {
+    if (typeof table !== "object" || table === null || Array.isArray(table)) {
+      throw new TypeError(`callback response tables[${tableIndex}] must be an object`);
+    }
+    const name = callbackName(
+      table.name,
+      `callback response tables[${tableIndex}].name`,
+      30,
+    );
+    if (names.has(name)) throw new Error(`callback response repeats table ${name}`);
+    names.add(name);
+    const rowByteLength = callbackUint32(
+      table.rowByteLength,
+      `callback response table ${name} rowByteLength`,
+    );
+    if (!Array.isArray(table.rows)) {
+      throw new TypeError(`callback response table ${name} rows must be an array`);
+    }
+    callbackUint32(table.rows.length, `callback response table ${name} row count`);
+    const rows = table.rows.map((row: Uint8Array, rowIndex: number) => {
+      const snapshot = boundedCallbackSnapshot(
+        row,
+        `callback response table ${name} row ${rowIndex}`,
+      );
+      if (snapshot.byteLength !== rowByteLength) {
+        throw new RangeError(
+          `callback response table ${name} row ${rowIndex} has ${snapshot.byteLength} bytes; expected ${rowByteLength}`,
+        );
+      }
+      return snapshot;
+    });
+    return Object.freeze({ name, rowByteLength, rows: Object.freeze(rows) });
+  }));
+}
+
+function encodeCallbackEnvelope(fields: readonly CpicField[]): Buffer {
+  return Buffer.concat([
+    CUT_RESPONSE_PREFIX,
+    encodeCpicFieldChain(CpicTag.ResponseStart, fields),
+    CUT_PACKET_SENTINEL,
+  ]);
+}
+
+/** Encode one raw successful callback response before APPC framing. */
+export function encodeCpicRfcCallbackResponse(
+  response: RfcCallbackResponse,
+): Buffer {
+  if (typeof response !== "object" || response === null || Array.isArray(response)) {
+    throw new TypeError("callback response must be an object");
+  }
+  const exports = snapshotNamedValues(response.exports, "callback response exports");
+  const tables = snapshotTables(response.tables);
+  const names = new Set(exports.map((entry) => entry.name));
+  for (const table of tables) {
+    if (names.has(table.name)) {
+      throw new Error(`callback response repeats parameter ${table.name}`);
+    }
+    names.add(table.name);
+  }
+  const fields: CpicField[] = [
+    { tag: CpicTag.Unresolved0420, value: Buffer.alloc(4) },
+  ];
+  for (const entry of exports) {
+    fields.push(
+      {
+        tag: CpicTag.ParameterName,
+        value: encodeCallbackName(entry.name, "callback export name", 30),
+      },
+      { tag: CpicTag.ParameterValue, value: entry.value },
+    );
+  }
+  for (const table of tables) {
+    const header = Buffer.alloc(8);
+    header.writeUInt32BE(table.rowByteLength, 0);
+    header.writeUInt32BE(table.rows.length, 4);
+    fields.push(
+      {
+        tag: CpicTag.TableName,
+        value: encodeCallbackName(table.name, "callback table name", 30),
+      },
+      { tag: CpicTag.TableHeader, value: header },
+      ...table.rows.map((row) => ({ tag: CpicTag.TableCompr, value: row })),
+    );
+  }
+  fields.push({ tag: CpicTag.End, value: Buffer.alloc(0) });
+  return encodeCallbackEnvelope(fields);
+}
+
+/** Encode a declared callback exception such as FU_NOT_FOUND. */
+export function encodeCpicRfcCallbackException(exceptionKey: string): Buffer {
+  return encodeCallbackEnvelope([
+    {
+      tag: CpicTag.AbapExceptionKey,
+      value: encodeCallbackName(exceptionKey, "callback exception key", 30),
+    },
+    { tag: CpicTag.End, value: Buffer.alloc(0) },
+  ]);
+}
+
+/** Add the compact SAP8 trailer, or retain the streamed sentinel for large replies. */
+export function frameCpicRfcCallbackResponse(
+  response: Uint8Array,
+): Buffer {
+  const snapshot = boundedCallbackSnapshot(response, "callback CUT response");
+  if (
+    snapshot.byteLength < 2 ||
+    snapshot.readUInt16BE(snapshot.byteLength - 2) !== CpicTag.End
+  ) {
+    throw new Error("callback CUT response lacks its packet sentinel");
+  }
+  let framed = snapshot;
+  if (snapshot.byteLength <= MAX_APPC_APPLICATION_DATA_FRAGMENT_LENGTH) {
+    const finalSap = Buffer.alloc(8);
+    finalSap.writeUInt16BE(0, 0);
+    finalSap.writeUInt16BE(snapshot.byteLength, 2);
+    finalSap.writeUInt32BE(MAXIMUM_RFC_PACKET_SIZE, 4);
+    framed = Buffer.concat([snapshot, finalSap]);
+  }
+  // Keep the framing function and the session planner aligned by validating
+  // the exact envelope here as well as at the eventual send boundary.
+  inspectCpicRequestAppcFraming(framed);
+  return framed;
+}
+
+/** Snapshot a public handler table once before any networking starts. */
+export function snapshotRfcCallbackHandlers(
+  handlers: RfcCallbackHandlers | undefined,
+  path = "callbacks",
+): ReadonlyMap<string, RfcCallbackHandler> | undefined {
+  if (handlers === undefined) return undefined;
+  if (
+    typeof handlers !== "object" ||
+    handlers === null ||
+    Array.isArray(handlers) ||
+    nodeUtilTypes.isProxy(handlers)
+  ) {
+    throw new TypeError(`${path} must be a plain object`);
+  }
+  const prototype = Object.getPrototypeOf(handlers);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError(`${path} must be a plain object`);
+  }
+  const names = Reflect.ownKeys(handlers);
+  if (names.length > DEFAULT_MAX_RFC_CALLBACKS_PER_CALL) {
+    throw new RangeError(
+      `${path} contains more than ${DEFAULT_MAX_RFC_CALLBACKS_PER_CALL} handlers`,
+    );
+  }
+  const snapshot = new Map<string, RfcCallbackHandler>();
+  for (const key of names) {
+    if (typeof key !== "string") throw new TypeError(`${path} keys must be strings`);
+    const name = callbackName(key, `${path} function name`, 40);
+    const descriptor = Object.getOwnPropertyDescriptor(handlers, key);
+    if (descriptor === undefined || !("value" in descriptor)) {
+      throw new TypeError(`${path}.${key} must be an own data property`);
+    }
+    if (typeof descriptor.value !== "function") {
+      throw new TypeError(`${path}.${key} must be a function`);
+    }
+    snapshot.set(name, descriptor.value as RfcCallbackHandler);
+  }
+  return snapshot;
+}
+
+/** @internal Assert callback response framing without exposing protocol helpers at package root. */
+export function inspectFramedCpicRfcCallbackResponse(
+  response: Uint8Array,
+): CpicRequestAppcFraming {
+  return inspectCpicRequestAppcFraming(response);
+}

--- a/src/values/classic-xrfc.ts
+++ b/src/values/classic-xrfc.ts
@@ -763,6 +763,11 @@ export function decodeClassicXrfcBase64(
   path: string,
   maximum: number,
 ): Buffer {
+  // SAP's xRFC producer MIME-wraps larger XSTRING cells at 76 columns. Remove
+  // only the two MIME line separators before the existing canonical checks;
+  // spaces and every other non-base64 character remain invalid. Adapted from
+  // open-rfc-go internal/xrfc at 92d5d8f6e0a08ff7ac1580f461585cbde2a56939.
+  value = value.replace(/[\r\n]/gu, "");
   if (value.length === 0) return Buffer.alloc(0);
   if (
     (value.length & 3) !== 0 ||

--- a/src/values/recursive-classic-xrfc.ts
+++ b/src/values/recursive-classic-xrfc.ts
@@ -1574,6 +1574,11 @@ function preflightScalar(
       assertNulFreeUnicodeScalarText(value, path);
       return;
     case "y": {
+      // SAP's xRFC producer MIME-wraps larger XSTRING cells at 76 columns.
+      // Remove only MIME line separators before canonical preflight. Adapted
+      // from open-rfc-go internal/xrfc at
+      // 92d5d8f6e0a08ff7ac1580f461585cbde2a56939.
+      value = value.replace(/[\r\n]/gu, "");
       if (
         (value.length & 3) !== 0 ||
         !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(value)

--- a/src/values/recursive-xrfc.ts
+++ b/src/values/recursive-xrfc.ts
@@ -1534,6 +1534,7 @@ class Parser {
 }
 
 function canonicalBase64(value: string, path: string, maximum: number): Buffer {
+  value = normalizeXrfcBase64(value);
   canonicalBase64DecodedByteLength(value, path, maximum);
   if (value.length === 0) return Buffer.alloc(0);
   const decoded = Buffer.from(value, "base64");
@@ -1548,6 +1549,7 @@ function canonicalBase64DecodedByteLength(
   path: string,
   maximum: number,
 ): number {
+  value = normalizeXrfcBase64(value);
   if (
     value.length > maximum ||
     (value.length & 3) !== 0 ||
@@ -1557,6 +1559,14 @@ function canonicalBase64DecodedByteLength(
   }
   return (value.length / 4) * 3 -
     (value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0);
+}
+
+// SAP's xRFC producer MIME-wraps larger XSTRING cells at 76 columns. Adapted
+// from open-rfc-go internal/xrfc at
+// 92d5d8f6e0a08ff7ac1580f461585cbde2a56939. Keep the normalization narrow so
+// spaces and every other non-base64 character still fail canonical validation.
+function normalizeXrfcBase64(value: string): string {
+  return value.replace(/[\r\n]/gu, "");
 }
 
 function parseCanonicalBigInt(value: string, path: string): bigint {

--- a/test/classic-xrfc.test.ts
+++ b/test/classic-xrfc.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import type { RfcStructureDefinition } from "../src/metadata/rfc-structure-definition.js";
 import {
+  decodeClassicXrfcBase64,
   decodeClassicXrfcParameter,
   decodeClassicXrfcParameterName,
   encodeClassicXrfcParameter,
@@ -354,6 +355,27 @@ test("supports a flat dynamic structure without item wrappers", () => {
   assert.deepEqual(
     decodeClassicXrfcParameter("ROW", STFC_ROW, "structure", encoded),
     CAPTURED_ROWS[0],
+  );
+});
+
+test("decodes SAP MIME-wrapped XSTRING cells without accepting spaces", () => {
+  const payload = Buffer.alloc(256);
+  for (let index = 0; index < payload.length; index += 1) {
+    payload[index] = index & 0xff;
+  }
+  const canonical = payload.toString("base64");
+  const wrapped = canonical.match(/.{1,76}/gu)!.join("\n");
+  assert.deepEqual(
+    decodeClassicXrfcBase64(wrapped, "ROW.XSTR", 1_024),
+    payload,
+  );
+  assert.deepEqual(
+    decodeClassicXrfcBase64(wrapped.replaceAll("\n", "\r\n"), "ROW.XSTR", 1_024),
+    payload,
+  );
+  assert.throws(
+    () => decodeClassicXrfcBase64(wrapped.replaceAll("\n", " "), "ROW.XSTR", 1_024),
+    /non-canonical base64/u,
   );
 });
 

--- a/test/direct-cpic-callback.test.ts
+++ b/test/direct-cpic-callback.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DirectCpicSession } from "../src/client/direct-cpic-session.js";
+import type { RfcFunctionInterface } from
+  "../src/metadata/rfc-function-interface.js";
+import {
+  decodeCpicFunctionResultFields,
+  encodeCpicCutFunctionRequest,
+} from "../src/protocol/cpic.js";
+import { DEFAULT_MAX_RFC_CALLBACKS_PER_CALL } from
+  "../src/protocol/rfc-callback.js";
+import { decodeClassicRfcResult } from "../src/protocol/classic-rfc.js";
+import {
+  ScriptedRfcPeer,
+  successfulRegularFields,
+} from "./support/scripted-rfc-peer.js";
+
+const OUTER_METADATA: RfcFunctionInterface = Object.freeze({
+  name: "Z_CALLBACK_OUTER",
+  remoteBasxmlSupported: false,
+  remoteCall: "R",
+  updateTask: false,
+  parameters: Object.freeze([]),
+  exceptions: Object.freeze([]),
+  resumableExceptionRowCount: 0,
+});
+
+function callbackRequest(functionName: string, text: string): Buffer {
+  const framed = encodeCpicCutFunctionRequest({
+    functionName,
+    requestedOutputs: ["ECHOTEXT"],
+    imports: [{
+      name: "REQUTEXT",
+      value: Buffer.from(text.padEnd(20, " "), "utf16le"),
+    }],
+  });
+  // An incoming APPC data message contains application data; its compact SAP8
+  // trailer is carried by the APPC record rather than inside message.data.
+  return framed.subarray(0, framed.byteLength - 8);
+}
+
+test("services multiple DESTINATION BACK callbacks before the outer response", async (t) => {
+  const callbackResponses: ReturnType<typeof decodeCpicFunctionResultFields>[] = [];
+  const peer = await ScriptedRfcPeer.start([{
+    replies: [{
+      kind: "callbacks",
+      requests: [
+        callbackRequest("STFC_CONNECTION", "one"),
+        callbackRequest("Z_UNKNOWN_CALLBACK", "two"),
+      ],
+      final: { kind: "fields", fields: successfulRegularFields() },
+      inspectResponse(response) {
+        callbackResponses.push(decodeCpicFunctionResultFields(response));
+      },
+    }],
+  }]);
+  t.after(() => peer.close());
+
+  const seen: string[] = [];
+  const session = await DirectCpicSession.open({
+    host: "127.0.0.1",
+    port: peer.port,
+    applicationServerService: "sapdp00",
+    operationTimeoutMs: 1_000,
+    callbacks: {
+      STFC_CONNECTION(request, context) {
+        assert.equal(context.callbackIndex, 1);
+        assert.equal(request.requestedOutputs[0], "ECHOTEXT");
+        const imported = request.imports[0]!;
+        assert.equal(imported.name, "REQUTEXT");
+        seen.push(imported.value.toString("utf16le").trimEnd());
+        return {
+          exports: [{ name: "ECHOTEXT", value: imported.value }],
+        };
+      },
+    },
+  });
+  await session.logonAndPing({
+    client: "001",
+    user: "RFCUSR",
+    password: "not-a-real-password",
+  });
+
+  const output = await session.invokeClassicWithMetadata(
+    OUTER_METADATA,
+    {},
+    new Map(),
+  );
+  assert.deepEqual(output, {});
+  assert.deepEqual(seen, ["one"]);
+  assert.equal(callbackResponses.length, 2);
+  assert.equal(callbackResponses[0]!.success, true);
+  assert.equal(
+    decodeClassicRfcResult(callbackResponses[0]!.fields)
+      .scalars[0]!.value.toString("utf16le").trimEnd(),
+    "one",
+  );
+  assert.equal(callbackResponses[1]!.success, false);
+  assert.equal(
+    callbackResponses[1]!.envelope.facts.exceptionKey,
+    "FU_NOT_FOUND",
+  );
+  assert.equal(peer.regularRequestCount(0), 1);
+  await session.close();
+});
+
+test("fails closed when a business call receives an unconfigured callback", async (t) => {
+  const peer = await ScriptedRfcPeer.start([{
+    replies: [{
+      kind: "callbacks",
+      requests: [callbackRequest("STFC_CONNECTION", "blocked")],
+      final: { kind: "fields", fields: successfulRegularFields() },
+    }],
+  }]);
+  t.after(() => peer.close());
+  const session = await DirectCpicSession.open({
+    host: "127.0.0.1",
+    port: peer.port,
+    applicationServerService: "sapdp00",
+    operationTimeoutMs: 1_000,
+  });
+  await session.logonAndPing({
+    client: "001",
+    user: "RFCUSR",
+    password: "not-a-real-password",
+  });
+  await assert.rejects(
+    session.invokeClassicWithMetadata(OUTER_METADATA, {}, new Map()),
+    /RFC_INVALID_PROTOCOL/u,
+  );
+  assert.equal(session.state, "closed");
+});
+
+test("fails closed when a callback handler attempts asynchronous work", async (t) => {
+  const peer = await ScriptedRfcPeer.start([{
+    replies: [{
+      kind: "callbacks",
+      requests: [callbackRequest("Z_ASYNC_CALLBACK", "blocked")],
+      final: { kind: "fields", fields: successfulRegularFields() },
+    }],
+  }]);
+  t.after(() => peer.close());
+  const session = await DirectCpicSession.open({
+    host: "127.0.0.1",
+    port: peer.port,
+    applicationServerService: "sapdp00",
+    operationTimeoutMs: 1_000,
+    callbacks: {
+      Z_ASYNC_CALLBACK: (() => Promise.resolve({})) as never,
+    },
+  });
+  await session.logonAndPing({
+    client: "001",
+    user: "RFCUSR",
+    password: "not-a-real-password",
+  });
+  await assert.rejects(
+    session.invokeClassicWithMetadata(OUTER_METADATA, {}, new Map()),
+    /RFC_INVALID_PROTOCOL/u,
+  );
+  assert.equal(session.state, "closed");
+});
+
+test("bounds callback recursion within one outer call", async (t) => {
+  let responses = 0;
+  const peer = await ScriptedRfcPeer.start([{
+    replies: [{
+      kind: "callbacks",
+      requests: Array.from(
+        { length: DEFAULT_MAX_RFC_CALLBACKS_PER_CALL + 1 },
+        (_, index) => callbackRequest("Z_BOUNDED_CALLBACK", `${index}`),
+      ),
+      final: { kind: "fields", fields: successfulRegularFields() },
+      inspectResponse() { responses += 1; },
+    }],
+  }]);
+  t.after(() => peer.close());
+  const session = await DirectCpicSession.open({
+    host: "127.0.0.1",
+    port: peer.port,
+    applicationServerService: "sapdp00",
+    operationTimeoutMs: 1_000,
+    callbacks: { Z_BOUNDED_CALLBACK: () => ({}) },
+  });
+  await session.logonAndPing({
+    client: "001",
+    user: "RFCUSR",
+    password: "not-a-real-password",
+  });
+  await assert.rejects(
+    session.invokeClassicWithMetadata(OUTER_METADATA, {}, new Map()),
+    /RFC_INVALID_PROTOCOL/u,
+  );
+  assert.equal(responses, DEFAULT_MAX_RFC_CALLBACKS_PER_CALL);
+  assert.equal(session.state, "closed");
+});

--- a/test/node-rfc-client-boundary.test.ts
+++ b/test/node-rfc-client-boundary.test.ts
@@ -375,6 +375,7 @@ test("snapshots and validates every compatibility client option before I/O", () 
   });
 
   const conversion = (value: string) => ({ decimal: value });
+  const callback = () => ({ exports: [] });
   const recursiveSerializerPolicy = {
     profile: "abap-7.58" as const,
     observation: {
@@ -389,6 +390,7 @@ test("snapshots and validates every compatibility client option before I/O", () 
     timeout: 0.001,
     logLevel: 0,
     recursiveSerializerPolicy,
+    callbacks: { Z_CALLBACK: callback },
   });
   recursiveSerializerPolicy.observation.defaultSerializer = "classic-xrfc";
   assert.deepEqual(valid, {
@@ -404,8 +406,11 @@ test("snapshots and validates every compatibility client option before I/O", () 
         basxmlDisabledSerializer: "classic-xrfc",
       },
     },
+    callbacks: { Z_CALLBACK: callback },
   });
   assert.equal(Object.isFrozen(valid), true);
+  assert.equal(Object.isFrozen(valid?.callbacks), true);
+  assert.equal(valid?.callbacks?.Z_CALLBACK, callback);
   assert.equal(Object.isFrozen(valid?.recursiveSerializerPolicy), true);
   assert.equal(
     Object.isFrozen(valid?.recursiveSerializerPolicy?.observation),
@@ -416,6 +421,11 @@ test("snapshots and validates every compatibility client option before I/O", () 
   assert.equal(snapshotRfcClientOptions({ bcd: conversion })?.bcd, conversion);
   assert.equal(snapshotRfcClientOptions({ int8Mode: "string" })?.int8Mode, "string");
   assert.equal(snapshotRfcClientOptions({ int8Mode: undefined })?.int8Mode, "number");
+  assert.equal(snapshotRfcClientOptions({ callbacks: undefined })?.callbacks, undefined);
+  assert.throws(
+    () => snapshotRfcClientOptions({ callbacks: { Z_CALLBACK: 1 as never } }),
+    /must be a function/u,
+  );
 
   for (const invalid of [null, [], "bad"]) {
     assert.throws(

--- a/test/node-rfc-compat.test.ts
+++ b/test/node-rfc-compat.test.ts
@@ -22,6 +22,8 @@ const configuration = {
   poolOptions: { low: 0, high: 1 },
 } as const;
 
+const callbackHandler = () => ({ exports: [] });
+
 function routedOwnerDouble(): DirectDestinationOwner {
   let idle = 0;
   const leases = new Set<object>();
@@ -63,35 +65,44 @@ test("archived Client composes message-server physical routing and direct preced
     },
   });
   try {
-    const message = new Client({
-      mshost: "message.example.test",
-      msserv: "sapmsQAS",
-      r3name: "QAS",
-      sysid: "IGN",
-      group: "PUBLIC",
-      client: "001",
-      user: "MESSAGE_USER",
-      passwd: ["message", "password"].join("-"),
-    });
+    const message = new Client(
+      {
+        mshost: "message.example.test",
+        msserv: "sapmsQAS",
+        r3name: "QAS",
+        sysid: "IGN",
+        group: "PUBLIC",
+        client: "001",
+        user: "MESSAGE_USER",
+        passwd: ["message", "password"].join("-"),
+      },
+      { callbacks: { Z_CALLBACK: callbackHandler } },
+    );
     await message.open();
     assert.equal(contexts[0]?.connection.host, "message.example.test");
     assert.equal(typeof contexts[0]?.sessionFactory?.open, "function");
+    assert.equal(contexts[0]?.session?.callbacks?.Z_CALLBACK, callbackHandler);
+    assert.equal(Object.isFrozen(contexts[0]?.session?.callbacks), true);
     assert.equal(JSON.stringify(message.connectionInfo).includes(["message", "password"].join("-")), false);
     await message.close();
 
-    const direct = new Client({
-      ashost: "direct.example.test",
-      sysnr: "01",
-      mshost: "ignored-message.example.test",
-      r3name: "IGN",
-      group: "PUBLIC",
-      client: "001",
-      user: "DIRECT_USER",
-      passwd: ["direct", "password"].join("-"),
-    });
+    const direct = new Client(
+      {
+        ashost: "direct.example.test",
+        sysnr: "01",
+        mshost: "ignored-message.example.test",
+        r3name: "IGN",
+        group: "PUBLIC",
+        client: "001",
+        user: "DIRECT_USER",
+        passwd: ["direct", "password"].join("-"),
+      },
+      { callbacks: { Z_CALLBACK: callbackHandler } },
+    );
     await direct.open();
     assert.equal(contexts[1]?.connection.host, "direct.example.test");
     assert.equal(contexts[1]?.sessionFactory, undefined);
+    assert.equal(contexts[1]?.session?.callbacks?.Z_CALLBACK, callbackHandler);
     await direct.close();
   } finally {
     restore();
@@ -117,11 +128,13 @@ test("archived Pool keeps group lookup at the per-physical session seam", async 
     },
     poolOptions: { low: 0, high: 2 },
     resourceOptions: { maxConnections: 2 },
+    clientOptions: { callbacks: { Z_CALLBACK: callbackHandler } },
   });
   try {
     await pool.ready(2);
     assert.equal(context?.connection.host, "message.example.test");
     assert.equal(typeof context?.sessionFactory?.open, "function");
+    assert.equal(context?.session?.callbacks?.Z_CALLBACK, callbackHandler);
     assert.deepEqual(pool.status, { ready: 2, leased: 0 });
   } finally {
     await pool.closeAll();

--- a/test/recursive-classic-xrfc.test.ts
+++ b/test/recursive-classic-xrfc.test.ts
@@ -1125,6 +1125,32 @@ test("rejects non-canonical later base64 before allocating earlier XSTRING value
   assert.equal(base64Allocations, 0);
 });
 
+test("decodes MIME-wrapped recursive classic XSTRING cells", () => {
+  const resolved = binarySiblingPlan();
+  const payload = Buffer.alloc(256);
+  for (let index = 0; index < payload.length; index += 1) {
+    payload[index] = (index * 29) & 0xff;
+  }
+  const wrapped = payload.toString("base64").match(/.{1,76}/gu)!.join("\n");
+  assert.deepEqual(
+    decodeRecursiveClassicXrfcParameter(
+      resolved,
+      Buffer.from(`<VALUE><LEFT>${wrapped}</LEFT><RIGHT>AA==</RIGHT></VALUE>`),
+    ),
+    { LEFT: payload, RIGHT: Buffer.from([0]) },
+  );
+  assert.throws(
+    () => decodeRecursiveClassicXrfcParameter(
+      resolved,
+      Buffer.from(
+        `<VALUE><LEFT>${wrapped.replaceAll("\n", " ")}</LEFT>` +
+          "<RIGHT>AA==</RIGHT></VALUE>",
+      ),
+    ),
+    /non-canonical base64/u,
+  );
+});
+
 test("rejects unknown/accessor values and hostile or non-canonical XML", () => {
   const resolved = plan();
   assert.throws(

--- a/test/recursive-xrfc.test.ts
+++ b/test/recursive-xrfc.test.ts
@@ -300,6 +300,31 @@ test("encodes and decodes nested structures, tables, and XSTRING exactly", () =>
   );
 });
 
+test("decodes MIME-wrapped recursive XSTRING cells", () => {
+  const payload = Buffer.alloc(256);
+  for (let index = 0; index < payload.length; index += 1) {
+    payload[index] = (index * 17) & 0xff;
+  }
+  const canonical = payload.toString("base64");
+  const wrapped = canonical.match(/.{1,76}/gu)!.join("\n");
+  const xml = Buffer.from(
+    "<ROOT><TEXT></TEXT><CHILD><COUNT>0</COUNT></CHILD>" +
+      "<ROWS></ROWS><BLOB>" + wrapped + "</BLOB></ROOT>",
+  );
+  assert.deepEqual(
+    decodeRecursiveXrfcParameter(ROOT_PARAMETER, ROOT_GRAPH, xml),
+    { TEXT: "", CHILD: { COUNT: 0 }, ROWS: [], BLOB: payload },
+  );
+  assert.throws(
+    () => decodeRecursiveXrfcParameter(
+      ROOT_PARAMETER,
+      ROOT_GRAPH,
+      Buffer.from(xml.toString().replaceAll("\n", " ")),
+    ),
+    /non-canonical base64/u,
+  );
+});
+
 test("integrates recursive graph values into the classic invocation envelope", () => {
   const outputParameter = interfaceParameter("OUT", "E", "Z_ROOT", "u");
   const metadata: RfcFunctionInterface = Object.freeze({

--- a/test/rfc-callback.test.ts
+++ b/test/rfc-callback.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CpicTag,
+  decodeCpicFunctionResultFields,
+  encodeCpicCutFunctionRequest,
+  encodeCpicFieldChain,
+} from "../src/protocol/cpic.js";
+import { decodeClassicRfcResult } from "../src/protocol/classic-rfc.js";
+import {
+  decodeCpicRfcCallbackRequest,
+  encodeCpicRfcCallbackException,
+  encodeCpicRfcCallbackResponse,
+  frameCpicRfcCallbackResponse,
+  inspectFramedCpicRfcCallbackResponse,
+  isCpicRfcCallbackRequest,
+  snapshotRfcCallbackHandlers,
+} from "../src/protocol/rfc-callback.js";
+
+test("decodes a bounded CUT callback request with raw values", () => {
+  const request = encodeCpicCutFunctionRequest({
+    functionName: "STFC_CONNECTION",
+    requestedOutputs: ["ECHOTEXT"],
+    imports: [{
+      name: "REQUTEXT",
+      value: Buffer.from("callback".padEnd(20, " "), "utf16le"),
+    }],
+    tables: [{
+      name: "ITEMS",
+      rowByteLength: 4,
+      rows: [Buffer.from("01020304", "hex")],
+    }],
+    xrfcParameters: [{
+      name: "DEEP",
+      value: Buffer.from("<DEEP><TEXT>one</TEXT></DEEP>"),
+    }],
+  });
+  assert.equal(isCpicRfcCallbackRequest(request), true);
+  const decoded = decodeCpicRfcCallbackRequest(
+    request.subarray(0, request.byteLength - 8),
+  );
+  assert.equal(decoded.functionName, "STFC_CONNECTION");
+  assert.equal(decoded.kernelRelease, "754");
+  assert.deepEqual(decoded.requestedOutputs, ["ECHOTEXT"]);
+  assert.equal(decoded.imports[0]!.name, "REQUTEXT");
+  assert.equal(decoded.imports[0]!.value.toString("utf16le").trimEnd(), "callback");
+  assert.deepEqual(decoded.tables, [{
+    name: "ITEMS",
+    rowByteLength: 4,
+    rows: [Buffer.from("01020304", "hex")],
+  }]);
+  assert.deepEqual(decoded.xrfcParameters, [{
+    value: Buffer.from("<DEEP><TEXT>one</TEXT></DEEP>"),
+    chunkCount: 1,
+  }]);
+});
+
+test("encodes callback success and declared-exception responses", () => {
+  const echo = Buffer.from("callback".padEnd(20, " "), "utf16le");
+  const response = encodeCpicRfcCallbackResponse({
+    exports: [{ name: "ECHOTEXT", value: echo }],
+    tables: [{
+      name: "ITEMS",
+      rowByteLength: 4,
+      rows: [Buffer.from("01020304", "hex")],
+    }],
+  });
+  const decoded = decodeCpicFunctionResultFields(response);
+  assert.equal(decoded.success, true);
+  const classic = decodeClassicRfcResult(decoded.fields);
+  assert.deepEqual(classic.scalars, [{ name: "ECHOTEXT", value: echo }]);
+  assert.deepEqual(classic.tables[0]?.rows, [Buffer.from("01020304", "hex")]);
+
+  const exception = decodeCpicFunctionResultFields(
+    encodeCpicRfcCallbackException("FU_NOT_FOUND"),
+  );
+  assert.equal(exception.success, false);
+  assert.equal(exception.envelope.outcome, "abapException");
+  assert.equal(exception.envelope.facts.exceptionKey, "FU_NOT_FOUND");
+});
+
+test("frames compact and streamed callback replies for the APPC sender", () => {
+  const compact = frameCpicRfcCallbackResponse(
+    encodeCpicRfcCallbackResponse({ exports: [] }),
+  );
+  assert.deepEqual(inspectFramedCpicRfcCallbackResponse(compact), {
+    mode: "compact",
+    applicationDataLength: compact.byteLength - 8,
+    finalSapParameterLength: 8,
+  });
+
+  const streamed = frameCpicRfcCallbackResponse(
+    encodeCpicRfcCallbackResponse({
+      exports: [{ name: "VALUE", value: Buffer.alloc(30_000, 0x41) }],
+    }),
+  );
+  assert.deepEqual(inspectFramedCpicRfcCallbackResponse(streamed), {
+    mode: "streamed",
+    applicationDataLength: streamed.byteLength,
+    finalSapParameterLength: 0,
+  });
+});
+
+test("rejects malformed callback grammar and unsafe handler tables", () => {
+  const badPrefix = Buffer.from("00000000ffff", "hex");
+  assert.equal(isCpicRfcCallbackRequest(badPrefix), false);
+  assert.throws(
+    () => decodeCpicRfcCallbackRequest(badPrefix),
+    /prefix is invalid/u,
+  );
+
+  const orphanValue = Buffer.concat([
+    Buffer.from("05020000", "hex"),
+    encodeCpicFieldChain(CpicTag.ContextEnd, [
+      { tag: CpicTag.Function, value: Buffer.from("Z_CALLBACK", "utf16le") },
+      { tag: CpicTag.ParameterValue, value: Buffer.of(1) },
+      { tag: CpicTag.End, value: Buffer.alloc(0) },
+    ]),
+    Buffer.from("ffff", "hex"),
+  ]);
+  assert.throws(
+    () => decodeCpicRfcCallbackRequest(orphanValue),
+    /value has no preceding name/u,
+  );
+
+  assert.throws(
+    () => snapshotRfcCallbackHandlers(new Proxy({}, {}) as never),
+    /plain object/u,
+  );
+  assert.throws(
+    () => snapshotRfcCallbackHandlers({ Z_CALLBACK: 1 as never }),
+    /must be a function/u,
+  );
+  const handler = () => ({ exports: [] });
+  const snapshotted = snapshotRfcCallbackHandlers({ Z_CALLBACK: handler });
+  assert.equal(snapshotted?.get("Z_CALLBACK"), handler);
+});

--- a/test/rfc-session-provider.test.ts
+++ b/test/rfc-session-provider.test.ts
@@ -758,6 +758,17 @@ test("route and provider registries reject ambiguous identities before selection
     }),
     /live-policy/u,
   );
+  assert.doesNotThrow(
+    () => new RFCClient(undefined, {
+      callbacks: { Z_CALLBACK: () => ({ exports: [] }) },
+    }),
+  );
+  assert.throws(
+    () => new RFCClient(undefined, {
+      callbacks: { Z_CALLBACK: 1 as never },
+    }),
+    /must be a function/u,
+  );
   assert.throws(
     () => bindRFCClientSessionProvider(null as never, {} as never),
     /binding expects an object identity/u,

--- a/test/support/scripted-rfc-peer.ts
+++ b/test/support/scripted-rfc-peer.ts
@@ -21,7 +21,7 @@ import {
   type CpicField,
 } from "../../src/protocol/cpic.js";
 
-export type ScriptedRegularRfcReply =
+export type ScriptedRfcDataReply =
   | {
       readonly kind: "fields";
       readonly fields: readonly CpicField[];
@@ -40,6 +40,16 @@ export type ScriptedRegularRfcReply =
       readonly appcReturnCode?: number;
       readonly sapReturnCode?: number;
       readonly isFinal?: boolean;
+    };
+
+export type ScriptedRegularRfcReply =
+  | ScriptedRfcDataReply
+  | {
+      /** Re-entrant server→client requests sent before the outer response. */
+      readonly kind: "callbacks";
+      readonly requests: readonly Uint8Array[];
+      readonly final: ScriptedRfcDataReply;
+      readonly inspectResponse?: (response: Buffer, index: number) => void;
     }
   | { readonly kind: "close" }
   | { readonly kind: "silence" };
@@ -69,6 +79,12 @@ interface GenerationState {
   barrierCount: number;
   streamedApplicationBytes: number;
   streamedDataOrdinal: number | undefined;
+  pendingCallbacks?: {
+    readonly requests: readonly Uint8Array[];
+    readonly final: ScriptedRfcDataReply;
+    readonly inspectResponse?: (response: Buffer, index: number) => void;
+    index: number;
+  };
 }
 
 function initialLogonResponse(status: number): Buffer {
@@ -209,6 +225,32 @@ export class ScriptedRfcPeer {
       return;
     }
     if (reply.kind === "silence") return;
+    if (reply.kind === "callbacks") {
+      if (reply.requests.length === 0) {
+        throw new Error("scripted callback reply needs at least one request");
+      }
+      state.pendingCallbacks = {
+        requests: reply.requests.map((request) => Buffer.from(request)),
+        final: reply.final,
+        inspectResponse: reply.inspectResponse,
+        index: 0,
+      };
+      this.#write(socket, encodeIncomingAppcDataRecord({
+        conversationId: state.conversationId,
+        communicationIndex: 0,
+        connectionIndex: state.connectionIndex,
+        data: reply.requests[0]!,
+      }));
+      return;
+    }
+    this.#sendDataReply(socket, state, reply);
+  }
+
+  #sendDataReply(
+    socket: Socket,
+    state: GenerationState,
+    reply: ScriptedRfcDataReply,
+  ): void {
     this.#write(socket, encodeIncomingAppcDataRecord({
       ...(reply.initialReceive ? { functionCode: AppcFunction.Receive } : {}),
       appcReturnCode: reply.appcReturnCode,
@@ -299,6 +341,32 @@ export class ScriptedRfcPeer {
     }
     if (header.functionCode === AppcFunction.Deallocate) {
       socket.end();
+      return;
+    }
+    if (state.pendingCallbacks !== undefined) {
+      if (header.functionCode !== AppcFunction.SapSend) {
+        throw new Error("scripted RFC peer expected a compact callback response");
+      }
+      const pending = state.pendingCallbacks;
+      const fragment = decodeAppcDataFragment(payload);
+      const response = fragment.data.subarray(
+        0,
+        fragment.data.byteLength - fragment.header.sapParameterLength,
+      );
+      pending.inspectResponse?.(response, pending.index);
+      pending.index += 1;
+      const next = pending.requests[pending.index];
+      if (next !== undefined) {
+        this.#write(socket, encodeIncomingAppcDataRecord({
+          conversationId: state.conversationId,
+          communicationIndex: 0,
+          connectionIndex: state.connectionIndex,
+          data: next,
+        }));
+      } else {
+        state.pendingCallbacks = undefined;
+        this.#sendDataReply(socket, state, pending.final);
+      }
       return;
     }
     if (


### PR DESCRIPTION
## Goal

Add the next interoperable classic-RFC pieces without widening the SDK-free Apache-2.0 boundary.

## Changes

- service server-initiated `DESTINATION BACK` calls on the active client conversation
- expose raw synchronous callback handlers on `Client`, `Pool`, and modern `RFCClient`
- return `FU_NOT_FOUND` for unknown callback RFMs
- fail closed for unconfigured, malformed, asynchronous, or excessive callbacks, with a limit of 64 per outer call
- accept SAP MIME-style LF/CRLF wrapping in flat and recursive xRFC XSTRING values while still rejecting spaces and non-canonical Base64
- document the preview API, safety constraints, support status, and exact third-party attribution

## Source and license

The protocol behavior is adapted from Apache-2.0 `open-rfc-go` commit `92d5d8f6e0a08ff7ac1580f461585cbde2a56939`. `THIRD_PARTY_NOTICES.md` records the exact source files, revision, license, and adaptation. No pysap/GPL source or packet capture is redistributed.

## Verification

- `npm test` — 966 tests passed
- `npm run lint`
- `npm run test:surface` — 20 tests passed
- strict `npm run docs:build`
- `npm pack --dry-run`

The TypeScript callback path was not run against a live SAP system from this workspace because no approved live profile is available. The upstream Go implementation reports live A4H verification; this PR therefore keeps callbacks explicitly documented as an offline-tested preview pending direct 7.50 and S/4HANA qualification.