### PR TITLE
fix: accept included structure field positions

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -56,6 +56,7 @@ contributors:
 - `src/protocol/logon-ticket.ts`
 - `src/protocol/cpic.ts`
 - `src/protocol/rfc-callback.ts`
+- `src/metadata/rfc-structure-definition.ts`
 - `src/values/classic-xrfc.ts`
 - `src/values/recursive-xrfc.ts`
 - `src/values/recursive-classic-xrfc.ts`
@@ -72,6 +73,7 @@ specifically these upstream files:
 - `internal/cpic/logon.go`
 - `internal/rfcserver/request.go`
 - `internal/rfcserver/response.go`
+- `internal/metadata/structure_definition.go`
 - `internal/client/session.go`
 - `rfc/callback.go`
 - `internal/xrfc/classic_xrfc.go`
@@ -124,6 +126,12 @@ The xRFC adaptation accepts SAP's MIME-style Base64 line wrapping for XSTRING
 cells. The TypeScript decoders remove only CR and LF before canonical Base64
 validation, retain the existing decoded and aggregate byte limits, and continue
 to reject spaces and all other non-canonical text.
+
+The structure-definition adaptation normalizes `RFC_FIELDS` rows into their
+authoritative returned order because included and appended DDIC components can
+repeat or skip informational `POSITION` values. It retains unique-name,
+non-overlap, non-negative, and total-structure bounds before exposing the
+normalized definition.
 
 The public repository and npm package include a copy of the Apache License,
 Version 2.0 in their root `LICENSE` file. Unless required by applicable law or

--- a/src/metadata/rfc-structure-definition.ts
+++ b/src/metadata/rfc-structure-definition.ts
@@ -11,6 +11,10 @@ import {
   type CpicField,
 } from "../protocol/cpic.js";
 
+// Included and appended DDIC structures can repeat or skip RFC_FIELDS
+// POSITION values. This normalization follows the Apache-2.0 open-rfc-go
+// correction at commit 92d5d8f6e0a08ff7ac1580f461585cbde2a56939.
+
 export const RFC_FIELDS_UNICODE_ROW_LENGTH = 138;
 const MAX_RFC_STRUCTURE_FIELDS = 20_000;
 
@@ -132,18 +136,21 @@ export function decodeRfcStructureDefinitionResult(
         `${fieldTable.rowByteLength}; expected at least ${RFC_FIELDS_UNICODE_ROW_LENGTH}`,
     );
   }
-  const decodedFields = fieldTable.rows.map((row) => decodeRfcFieldsRow(row));
+  const decodedFields = fieldTable.rows.map((row, index) => {
+    const field = decodeRfcFieldsRow(row);
+    return {
+      ...field,
+      // POSITION is informational for included/append components and is not
+      // guaranteed to be a dense 1..n sequence. The returned row order is the
+      // authoritative sequence; the geometric invariants below still protect
+      // the structure layout.
+      position: index + 1,
+    };
+  });
   const names = new Set<string>();
   let previousEnd = 0;
   for (let index = 0; index < decodedFields.length; index += 1) {
     const field = decodedFields[index]!;
-    const expectedPosition = index + 1;
-    if (field.position !== expectedPosition) {
-      throw new Error(
-        `RFC_FIELDS ${field.fieldName} has position ${field.position}; ` +
-          `expected ${expectedPosition}`,
-      );
-    }
     if (field.tableName !== structureName) {
       throw new Error(
         `RFC_FIELDS ${field.fieldName} belongs to ${field.tableName}; ` +

--- a/test/rfc-structure-definition.test.ts
+++ b/test/rfc-structure-definition.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RFC_FIELDS_UNICODE_ROW_LENGTH,
+  decodeRfcStructureDefinitionResult,
+} from "../src/metadata/rfc-structure-definition.js";
+import { encodeAbapChar } from "../src/protocol/classic-rfc.js";
+import { CpicTag, type CpicField } from "../src/protocol/cpic.js";
+
+interface FieldInput {
+  readonly name: string;
+  readonly position: number;
+  readonly offset: number;
+  readonly length: number;
+}
+
+function fieldRow(input: FieldInput): Buffer {
+  const row = Buffer.alloc(RFC_FIELDS_UNICODE_ROW_LENGTH);
+  encodeAbapChar("Z_INCLUDED", 30).copy(row, 0);
+  encodeAbapChar(input.name, 30).copy(row, 60);
+  row.writeInt32LE(input.position, 120);
+  row.writeInt32LE(input.offset, 124);
+  row.writeInt32LE(input.length, 128);
+  row.writeInt32LE(0, 132);
+  encodeAbapChar("C", 1).copy(row, 136);
+  return row;
+}
+
+function resultFields(rows: readonly Buffer[], byteLength = 12): readonly CpicField[] {
+  const length = Buffer.alloc(4);
+  length.writeInt32LE(byteLength);
+  const header = Buffer.alloc(8);
+  header.writeUInt32BE(RFC_FIELDS_UNICODE_ROW_LENGTH, 0);
+  header.writeUInt32BE(rows.length, 4);
+  return [
+    { tag: CpicTag.ParameterName, value: encodeAbapChar("TABLENGTH", 9) },
+    { tag: CpicTag.ParameterValue, value: length },
+    { tag: CpicTag.TableName, value: encodeAbapChar("FIELDS", 6) },
+    { tag: CpicTag.TableHeader, value: header },
+    ...rows.map((value) => ({ tag: CpicTag.TableContent, value })),
+  ];
+}
+
+test("normalizes non-dense RFC_FIELDS positions from included structures", () => {
+  const definition = decodeRfcStructureDefinitionResult(
+    "Z_INCLUDED",
+    resultFields([
+      fieldRow({ name: "HEAD", position: 4, offset: 0, length: 4 }),
+      fieldRow({ name: "INCLUDED_A", position: 1, offset: 4, length: 4 }),
+      fieldRow({ name: "INCLUDED_B", position: 1, offset: 8, length: 4 }),
+    ]),
+  );
+
+  assert.deepEqual(
+    definition.fields.map(({ fieldName, position, offset }) => ({
+      fieldName,
+      position,
+      offset,
+    })),
+    [
+      { fieldName: "HEAD", position: 1, offset: 0 },
+      { fieldName: "INCLUDED_A", position: 2, offset: 4 },
+      { fieldName: "INCLUDED_B", position: 3, offset: 8 },
+    ],
+  );
+});
+
+test("keeps structural geometry authoritative after position normalization", () => {
+  assert.throws(
+    () => decodeRfcStructureDefinitionResult(
+      "Z_INCLUDED",
+      resultFields([
+        fieldRow({ name: "FIRST", position: 8, offset: 0, length: 8 }),
+        fieldRow({ name: "SECOND", position: 8, offset: 4, length: 4 }),
+      ]),
+    ),
+    /overlaps/u,
+  );
+  assert.throws(
+    () => decodeRfcStructureDefinitionResult(
+      "Z_INCLUDED",
+      resultFields([
+        fieldRow({ name: "DUP", position: 9, offset: 0, length: 4 }),
+        fieldRow({ name: "DUP", position: 2, offset: 4, length: 4 }),
+      ]),
+    ),
+    /duplicate field/u,
+  );
+  assert.throws(
+    () => decodeRfcStructureDefinitionResult(
+      "Z_INCLUDED",
+      resultFields([
+        fieldRow({ name: "TOO_LONG", position: 3, offset: 8, length: 8 }),
+      ]),
+    ),
+    /beyond structure length/u,
+  );
+});


### PR DESCRIPTION
## Goal
Accept valid `RFC_GET_STRUCTURE_DEFINITION` results for DDIC structures containing includes or appends, whose informational `RFC_FIELDS-POSITION` values may repeat or skip.

## Content
- normalize field positions from authoritative response row order
- retain table-name, unique-name, non-overlap, and total-length validation
- add focused regression and geometry tests
- record the pinned Apache-2.0 open-rfc-go source and adaptation

## Verification
- `npm test` (968 tests)
- `npm run lint`