### PR TITLE
fix: resolve legacy table type row structures

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -131,7 +131,9 @@ The structure-definition adaptation normalizes `RFC_FIELDS` rows into their
 authoritative returned order because included and appended DDIC components can
 repeat or skip informational `POSITION` values. It retains unique-name,
 non-overlap, non-negative, and total-structure bounds before exposing the
-normalized definition.
+normalized definition. For legacy table-type metadata, it also detects the
+distinct row-structure owner and performs one bounded dereference instead of
+rejecting the valid owner mismatch or following an unbounded alias chain.
 
 The public repository and npm package include a copy of the Apache License,
 Version 2.0 in their root `LICENSE` file. Unless required by applicable law or

--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -222,8 +222,8 @@
     },
     {
       "path": "dist/src/metadata/rfc-structure-definition.d.ts",
-      "bytes": 1248,
-      "sha256": "fe99785891d5469e72f3891fbdf203780e52b61b7a403878a18392b1052a8318"
+      "bytes": 1540,
+      "sha256": "99d4c2908d65e226d12bbc0a4dc447dc84b50da1be9bc75db8f2dfb852ff3a2e"
     },
     {
       "path": "dist/src/pool/connection-pool-runtime.d.ts",
@@ -396,5 +396,5 @@
       "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "dcc8824b1cf51b6d63a4cf2fceab74dcf7481d6e1978b575ae488b654c92e473"
+  "aggregateSha256": "4428b7b417bc380a4addbe7d92467d27f3e929af3991cdf0ab3dcf5e336ba7ea"
 }

--- a/src/client/direct-cpic-session.ts
+++ b/src/client/direct-cpic-session.ts
@@ -82,6 +82,7 @@ import { createRecursiveMetadataParameterIndex } from
   "../metadata/recursive-parameter-index.js";
 import {
   buildRfcGetStructureDefinitionRequest,
+  detectRfcStructureDefinitionRowName,
   decodeRfcStructureDefinitionResult,
   type RfcStructureDefinition,
 } from "../metadata/rfc-structure-definition.js";
@@ -1557,11 +1558,30 @@ export class DirectCpicSession {
       signal,
     );
     const decoded = await this.#decodeRegularResponse(response);
+    const rowName = await this.#decodeApplicationResult(() =>
+      detectRfcStructureDefinitionRowName(structureName, decoded.fields));
+    if (rowName !== undefined) {
+      const cachedRow = this.#structures.get(rowName);
+      if (cachedRow !== undefined) {
+        this.#structures.set(structureName, cachedRow);
+        return cachedRow;
+      }
+      // RFC_GET_STRUCTURE_DEFINITION answers a table-type query with fields
+      // owned by its line structure. Resolve that concrete structure once;
+      // do not recursively follow peer-controlled aliases without a bound.
+      const rowResponse = await this.exchange(
+        buildRfcGetStructureDefinitionRequest(rowName),
+        signal,
+      );
+      const decodedRow = await this.#decodeRegularResponse(rowResponse);
+      const rowDefinition = await this.#decodeApplicationResult(() =>
+        decodeRfcStructureDefinitionResult(rowName, decodedRow.fields));
+      this.#structures.set(rowName, rowDefinition);
+      this.#structures.set(structureName, rowDefinition);
+      return rowDefinition;
+    }
     const definition = await this.#decodeApplicationResult(() =>
-      decodeRfcStructureDefinitionResult(
-        structureName,
-        decoded.fields,
-      ));
+      decodeRfcStructureDefinitionResult(structureName, decoded.fields));
     this.#structures.set(structureName, definition);
     return definition;
   }

--- a/src/metadata/rfc-structure-definition.ts
+++ b/src/metadata/rfc-structure-definition.ts
@@ -98,6 +98,38 @@ function requiredScalar(
   return scalar.value;
 }
 
+/**
+ * Detect the distinct DDIC line structure described for a queried table type.
+ * Ordinary structures return undefined; mixed row owners are malformed.
+ */
+export function detectRfcStructureDefinitionRowName(
+  queriedName: string,
+  fields: readonly CpicField[],
+): string | undefined {
+  const result = decodeClassicRfcResult(fields);
+  const fieldTable = result.tables.find((table) => table.name === "FIELDS");
+  if (fieldTable === undefined || fieldTable.rows.length === 0) return undefined;
+  if (fieldTable.rows.length > MAX_RFC_STRUCTURE_FIELDS) {
+    throw new RangeError(
+      `RFC_GET_STRUCTURE_DEFINITION FIELDS must contain at most ` +
+        `${MAX_RFC_STRUCTURE_FIELDS} rows`,
+    );
+  }
+
+  let rowName: string | undefined;
+  for (const row of fieldTable.rows) {
+    const field = decodeRfcFieldsRow(row);
+    if (rowName === undefined) rowName = field.tableName;
+    else if (field.tableName !== rowName) {
+      throw new Error(
+        `RFC_FIELDS rows belong to multiple structures: ${rowName} and ` +
+          `${field.tableName}`,
+      );
+    }
+  }
+  return rowName === queriedName ? undefined : rowName;
+}
+
 /** Normalize and validate RFC_GET_STRUCTURE_DEFINITION output. */
 export function decodeRfcStructureDefinitionResult(
   structureName: string,

--- a/test/rfc-structure-definition.test.ts
+++ b/test/rfc-structure-definition.test.ts
@@ -3,12 +3,14 @@ import test from "node:test";
 
 import {
   RFC_FIELDS_UNICODE_ROW_LENGTH,
+  detectRfcStructureDefinitionRowName,
   decodeRfcStructureDefinitionResult,
 } from "../src/metadata/rfc-structure-definition.js";
 import { encodeAbapChar } from "../src/protocol/classic-rfc.js";
 import { CpicTag, type CpicField } from "../src/protocol/cpic.js";
 
 interface FieldInput {
+  readonly tableName?: string;
   readonly name: string;
   readonly position: number;
   readonly offset: number;
@@ -17,7 +19,7 @@ interface FieldInput {
 
 function fieldRow(input: FieldInput): Buffer {
   const row = Buffer.alloc(RFC_FIELDS_UNICODE_ROW_LENGTH);
-  encodeAbapChar("Z_INCLUDED", 30).copy(row, 0);
+  encodeAbapChar(input.tableName ?? "Z_INCLUDED", 30).copy(row, 0);
   encodeAbapChar(input.name, 30).copy(row, 60);
   row.writeInt32LE(input.position, 120);
   row.writeInt32LE(input.offset, 124);
@@ -95,5 +97,55 @@ test("keeps structural geometry authoritative after position normalization", () 
       ]),
     ),
     /beyond structure length/u,
+  );
+});
+
+test("detects a table type's distinct row structure without accepting mixed owners", () => {
+  const rowFields = resultFields([
+    fieldRow({
+      tableName: "Z_LINE",
+      name: "FIRST",
+      position: 1,
+      offset: 0,
+      length: 4,
+    }),
+    fieldRow({
+      tableName: "Z_LINE",
+      name: "SECOND",
+      position: 2,
+      offset: 4,
+      length: 4,
+    }),
+  ]);
+  assert.equal(
+    detectRfcStructureDefinitionRowName("Z_TABLE_TYPE", rowFields),
+    "Z_LINE",
+  );
+  assert.equal(
+    detectRfcStructureDefinitionRowName("Z_LINE", rowFields),
+    undefined,
+  );
+
+  assert.throws(
+    () => detectRfcStructureDefinitionRowName(
+      "Z_TABLE_TYPE",
+      resultFields([
+        fieldRow({
+          tableName: "Z_LINE_A",
+          name: "FIRST",
+          position: 1,
+          offset: 0,
+          length: 4,
+        }),
+        fieldRow({
+          tableName: "Z_LINE_B",
+          name: "SECOND",
+          position: 2,
+          offset: 4,
+          length: 4,
+        }),
+      ]),
+    ),
+    /multiple structures/u,
   );
 });


### PR DESCRIPTION
## Goal
Allow the explicit legacy-v3 metadata path to resolve DDIC table types whose `RFC_FIELDS` rows belong to a distinct line structure.

## Content
- detect one consistent row-structure owner from the legacy response
- perform one bounded dereference and cache the definition under both names
- reject mixed owners and avoid unbounded peer-controlled alias traversal
- extend focused metadata regression tests and Apache-2.0 attribution
- refresh the reviewed declaration snapshot for the internal helper

## Verification
- `npm test` (969 tests)
- `npm run test:surface`
- `npm run lint`