### PR TITLE
feat: return declared RFC callback exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,11 @@ npm record identify the released source and package.
   part of the live-qualified beta support contract yet.
 - Server-initiated RFC calls made with ABAP `DESTINATION 'BACK'` are an
   implemented preview for classic client calls. Configure raw synchronous
-  handlers through `clientOptions.callbacks`; unknown functions receive
-  `FU_NOT_FOUND`, malformed callback traffic retires the session, and one outer
-  call is limited to 64 callbacks. This path is protocol- and scripted-socket
-  tested but has not been live-qualified by this TypeScript implementation.
+  handlers through `clientOptions.callbacks`; handlers can return a named
+  declared exception, unknown functions receive `FU_NOT_FOUND`, malformed
+  callback traffic retires the session, and one outer call is limited to 64
+  callbacks. This path is protocol- and scripted-socket tested but has not been
+  live-qualified by this TypeScript implementation.
 - WebSocket RFC business calls, Cloud Connector principal propagation, SNC,
   and X.509 are not supported and fail closed before business I/O when their
   required provider or authentication capability is absent.

--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -287,8 +287,8 @@
     },
     {
       "path": "dist/src/protocol/rfc-callback.d.ts",
-      "bytes": 2831,
-      "sha256": "7f2b9ef32babd955dd4738588b87f33ffa5e2a06149d0cbd25c9418e16e288e2"
+      "bytes": 2926,
+      "sha256": "2dfba81769c194df8b7cdd9b3a17045fff80aa8bec99f3a1e61fe0bbb3ee5604"
     },
     {
       "path": "dist/src/protocol/rfc-error-envelope.d.ts",
@@ -396,5 +396,5 @@
       "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "4428b7b417bc380a4addbe7d92467d27f3e929af3991cdf0ab3dcf5e336ba7ea"
+  "aggregateSha256": "a815c89322830bcbe4f5a4903af7e1992fc1e0bf0bc4ffa52a440dafacb5c01f"
 }

--- a/src/protocol/rfc-callback.ts
+++ b/src/protocol/rfc-callback.ts
@@ -49,10 +49,12 @@ export interface RfcCallbackRequest {
   readonly xrfcParameters: readonly RfcCallbackXrfcParameter[];
 }
 
-/** Raw classic-RFC values returned to one server-initiated callback. */
+/** Raw classic-RFC values or one declared exception returned to a callback. */
 export interface RfcCallbackResponse {
   readonly exports?: readonly RfcCallbackNamedValue[];
   readonly tables?: readonly RfcCallbackTable[];
+  /** Mutually exclusive with exports and tables. */
+  readonly exception?: string;
 }
 
 export interface RfcCallbackContext {
@@ -424,6 +426,24 @@ export function encodeCpicRfcCallbackResponse(
 ): Buffer {
   if (typeof response !== "object" || response === null || Array.isArray(response)) {
     throw new TypeError("callback response must be an object");
+  }
+  const exception = Object.getOwnPropertyDescriptor(response, "exception");
+  if (exception !== undefined) {
+    if (!("value" in exception) || typeof exception.value !== "string") {
+      throw new TypeError("callback response exception must be an own string value");
+    }
+    for (const key of ["exports", "tables"] as const) {
+      const conflicting = Object.getOwnPropertyDescriptor(response, key);
+      if (
+        conflicting !== undefined &&
+        (!("value" in conflicting) || conflicting.value !== undefined)
+      ) {
+        throw new Error(
+          `callback exception response must not include ${key}`,
+        );
+      }
+    }
+    return encodeCpicRfcCallbackException(exception.value);
   }
   const exports = snapshotNamedValues(response.exports, "callback response exports");
   const tables = snapshotTables(response.tables);

--- a/test/direct-cpic-callback.test.ts
+++ b/test/direct-cpic-callback.test.ts
@@ -47,6 +47,7 @@ test("services multiple DESTINATION BACK callbacks before the outer response", a
       kind: "callbacks",
       requests: [
         callbackRequest("STFC_CONNECTION", "one"),
+        callbackRequest("Z_DECLARED_CALLBACK", "declared"),
         callbackRequest("Z_UNKNOWN_CALLBACK", "two"),
       ],
       final: { kind: "fields", fields: successfulRegularFields() },
@@ -74,6 +75,10 @@ test("services multiple DESTINATION BACK callbacks before the outer response", a
           exports: [{ name: "ECHOTEXT", value: imported.value }],
         };
       },
+      Z_DECLARED_CALLBACK(_request, context) {
+        assert.equal(context.callbackIndex, 2);
+        return { exception: "NO_AUTHORITY" };
+      },
     },
   });
   await session.logonAndPing({
@@ -89,7 +94,7 @@ test("services multiple DESTINATION BACK callbacks before the outer response", a
   );
   assert.deepEqual(output, {});
   assert.deepEqual(seen, ["one"]);
-  assert.equal(callbackResponses.length, 2);
+  assert.equal(callbackResponses.length, 3);
   assert.equal(callbackResponses[0]!.success, true);
   assert.equal(
     decodeClassicRfcResult(callbackResponses[0]!.fields)
@@ -99,6 +104,11 @@ test("services multiple DESTINATION BACK callbacks before the outer response", a
   assert.equal(callbackResponses[1]!.success, false);
   assert.equal(
     callbackResponses[1]!.envelope.facts.exceptionKey,
+    "NO_AUTHORITY",
+  );
+  assert.equal(callbackResponses[2]!.success, false);
+  assert.equal(
+    callbackResponses[2]!.envelope.facts.exceptionKey,
     "FU_NOT_FOUND",
   );
   assert.equal(peer.regularRequestCount(0), 1);

--- a/test/rfc-callback.test.ts
+++ b/test/rfc-callback.test.ts
@@ -78,6 +78,22 @@ test("encodes callback success and declared-exception responses", () => {
   assert.equal(exception.success, false);
   assert.equal(exception.envelope.outcome, "abapException");
   assert.equal(exception.envelope.facts.exceptionKey, "FU_NOT_FOUND");
+
+  const handlerException = decodeCpicFunctionResultFields(
+    encodeCpicRfcCallbackResponse({ exception: "NO_AUTHORITY" }),
+  );
+  assert.equal(handlerException.success, false);
+  assert.equal(
+    handlerException.envelope.facts.exceptionKey,
+    "NO_AUTHORITY",
+  );
+  assert.throws(
+    () => encodeCpicRfcCallbackResponse({
+      exception: "NO_AUTHORITY",
+      exports: [],
+    } as never),
+    /must not include exports/u,
+  );
 });
 
 test("frames compact and streamed callback replies for the APPC sender", () => {


### PR DESCRIPTION
## Goal
Let configured `DESTINATION BACK` handlers return a declared ABAP exception while preserving the same RFC conversation.

## Content
- add optional `exception` to the callback response contract
- encode named exceptions through the existing strict CUT envelope
- reject ambiguous exception responses that also contain exports or tables
- prove a success, configured exception, unknown callback, and final outer response on one scripted session
- document the preview behavior and refresh the declaration snapshot

## Verification
- `npm test` (969 tests)
- `npm run test:surface`
- `npm run lint`
- strict `npm run docs:build`