### PR TITLE
fix: expand compressed callback table rows

### DIFF
--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -242,8 +242,8 @@
     },
     {
       "path": "dist/src/protocol/classic-rfc.d.ts",
-      "bytes": 4427,
-      "sha256": "dff71e9dc26b18e9af845f3cc4892cb8f1ceb536d4bd27e9ec7587110e46d7a3"
+      "bytes": 4669,
+      "sha256": "bc5e42275a190382860ae1bd611e16ab961cc70f7443fce570896f0b0f6a7815"
     },
     {
       "path": "dist/src/protocol/cpic.d.ts",
@@ -396,5 +396,5 @@
       "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "a815c89322830bcbe4f5a4903af7e1992fc1e0bf0bc4ffa52a440dafacb5c01f"
+  "aggregateSha256": "59d0b1664ee0c88914599977edaf6afe4a02fb05ec5a8d040aca8e0ccc2c3993"
 }

--- a/src/protocol/classic-rfc.ts
+++ b/src/protocol/classic-rfc.ts
@@ -207,6 +207,26 @@ function decodeSimpleCompressedTableRow(
   return decoded;
 }
 
+/**
+ * Decode one retained simple-compressed classic-RFC table row.
+ *
+ * @internal
+ */
+export function decodeSimpleCompressedRfcTableRow(
+  value: Uint8Array,
+  declaredRowByteLength: number,
+  tableName: string,
+  rowIndex: number,
+): Buffer {
+  return decodeSimpleCompressedTableRow(
+    value,
+    declaredRowByteLength,
+    tableName,
+    rowIndex,
+    false,
+  );
+}
+
 function borrowedWireBuffer(value: Uint8Array, path: string): Buffer {
   const view = intrinsicUint8ArrayView(value, path);
   return Buffer.from(view.buffer, view.byteOffset, view.byteLength);

--- a/src/protocol/rfc-callback.ts
+++ b/src/protocol/rfc-callback.ts
@@ -16,6 +16,7 @@ import {
 } from "./bytes.js";
 import { MAX_APPC_APPLICATION_DATA_FRAGMENT_LENGTH } from "./appc.js";
 import { assertUnicodeScalarText } from "../values/unicode-scalar.js";
+import { decodeSimpleCompressedRfcTableRow } from "./classic-rfc.js";
 
 // Adapted and hardened for TypeScript from open-rfc-go's Apache-2.0
 // internal/rfcserver request/response codec and rfc/callback framing at commit
@@ -191,6 +192,7 @@ export function decodeCpicRfcCallbackRequest(
     const tables: RfcCallbackTable[] = [];
     const xrfcParameters: RfcCallbackXrfcParameter[] = [];
     const names = new Set<string>();
+    let decodedTableBytes = 0n;
 
     for (let index = 0; index < decoded.fields.length; index += 1) {
       const field = decoded.fields[index]!;
@@ -254,17 +256,49 @@ export function decodeCpicRfcCallbackRequest(
           const rowByteLength = headerField.value.readUInt32BE(0);
           const rowCount = headerField.value.readUInt32BE(4);
           const rows: Buffer[] = [];
+          let tableDecodedBytes = 0n;
           index += 2;
           while (
             rows.length < rowCount &&
             (decoded.fields[index]?.tag === CpicTag.TableContent ||
               decoded.fields[index]?.tag === CpicTag.TableCompr)
           ) {
-            const row = decoded.fields[index]!.value;
+            const rowField = decoded.fields[index]!;
+            const row = rowField.value;
             if (row.byteLength === 0 || row.byteLength > rowByteLength) {
               throw new Error(`callback table ${name} row ${rows.length} has invalid length`);
             }
-            rows.push(Buffer.from(row));
+            const retainedByteLength = rowField.tag === CpicTag.TableCompr
+              ? rowByteLength
+              : row.byteLength;
+            tableDecodedBytes += BigInt(retainedByteLength);
+            if (
+              tableDecodedBytes > BigInt(DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH)
+            ) {
+              throw new RangeError(
+                `callback table ${name} decoded bytes exceed ` +
+                  `${DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH}`,
+              );
+            }
+            decodedTableBytes += BigInt(retainedByteLength);
+            if (
+              decodedTableBytes > BigInt(DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH)
+            ) {
+              throw new RangeError(
+                `callback decoded table bytes exceed ` +
+                  `${DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH}`,
+              );
+            }
+            rows.push(
+              rowField.tag === CpicTag.TableCompr
+                ? decodeSimpleCompressedRfcTableRow(
+                  row,
+                  rowByteLength,
+                  name,
+                  rows.length,
+                )
+                : Buffer.from(row),
+            );
             index += 1;
           }
           if (rows.length !== rowCount) {

--- a/test/rfc-callback.test.ts
+++ b/test/rfc-callback.test.ts
@@ -56,6 +56,36 @@ test("decodes a bounded CUT callback request with raw values", () => {
   }]);
 });
 
+test("expands bounded simple-compressed callback table rows", () => {
+  const request = (rowByteLength: number): Buffer => {
+    const tableHeader = Buffer.alloc(8);
+    tableHeader.writeUInt32BE(rowByteLength, 0);
+    tableHeader.writeUInt32BE(1, 4);
+    return Buffer.concat([
+      Buffer.from("05020000", "hex"),
+      encodeCpicFieldChain(CpicTag.ContextEnd, [
+        { tag: CpicTag.Function, value: Buffer.from("Z_CALLBACK", "utf16le") },
+        { tag: CpicTag.TableName, value: Buffer.from("ITEMS", "utf16le") },
+        { tag: CpicTag.TableHeader, value: tableHeader },
+        { tag: CpicTag.TableCompr, value: Buffer.from("4120", "hex") },
+        { tag: CpicTag.End, value: Buffer.alloc(0) },
+      ]),
+      Buffer.from("ffff", "hex"),
+    ]);
+  };
+
+  assert.deepEqual(decodeCpicRfcCallbackRequest(request(4)).tables, [{
+    name: "ITEMS",
+    rowByteLength: 4,
+    rows: [Buffer.from("41202020", "hex")],
+  }]);
+
+  assert.throws(
+    () => decodeCpicRfcCallbackRequest(request(0xffff_ffff)),
+    /decoded bytes exceed/u,
+  );
+});
+
 test("encodes callback success and declared-exception responses", () => {
   const echo = Buffer.from("callback".padEnd(20, " "), "utf16le");
   const response = encodeCpicRfcCallbackResponse({


### PR DESCRIPTION
## Goal
Deliver callback table rows to handlers as their bounded raw classic-RFC values.

## Content
- reuse the existing simple-compression decoder for inbound callback tables
- bound per-table and aggregate expanded bytes before allocation
- cover expansion and oversized-row rejection
- refresh the declaration snapshot for the internal helper