### PR TITLE
fix: bound callback response values

### DIFF
--- a/src/protocol/cpic.ts
+++ b/src/protocol/cpic.ts
@@ -1744,6 +1744,9 @@ export function encodeCpicCutFunctionRequest(
         `${table.name} row count exceeds the unsigned 32-bit range`,
       );
     }
+    if (table.rows.length !== 0 && table.rowByteLength === 0) {
+      throw new RangeError(`${table.name} cannot contain zero-width rows`);
+    }
     const header = Buffer.alloc(8);
     header.writeUInt32BE(table.rowByteLength, 0);
     header.writeUInt32BE(table.rows.length, 4);

--- a/src/protocol/rfc-callback.ts
+++ b/src/protocol/rfc-callback.ts
@@ -126,6 +126,7 @@ function callbackUint32(value: number, path: string): number {
 function boundedCallbackSnapshot(
   value: Uint8Array,
   path: string,
+  budget?: { retainedBytes: bigint },
 ): Buffer {
   if (!(value instanceof Uint8Array)) {
     throw new TypeError(`${path} must be a Uint8Array`);
@@ -136,7 +137,31 @@ function boundedCallbackSnapshot(
       `${path} exceeds ${DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH} bytes`,
     );
   }
+  if (budget !== undefined) {
+    budget.retainedBytes += BigInt(byteLength);
+    if (
+      budget.retainedBytes > BigInt(DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH)
+    ) {
+      throw new RangeError(
+        `callback response value bytes exceed ` +
+          `${DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH}`,
+      );
+    }
+  }
   return snapshotUint8Array(value, path, byteLength);
+}
+
+function reserveCallbackResponseBytes(
+  budget: { retainedBytes: bigint },
+  byteLength: bigint,
+): void {
+  budget.retainedBytes += byteLength;
+  if (budget.retainedBytes > BigInt(DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH)) {
+    throw new RangeError(
+      `callback response value bytes exceed ` +
+        `${DEFAULT_MAX_CPIC_FIELD_CHAIN_LENGTH}`,
+    );
+  }
 }
 
 function exactCallbackTrailer(
@@ -385,11 +410,12 @@ export function decodeCpicRfcCallbackRequest(
 function snapshotNamedValues(
   values: readonly RfcCallbackNamedValue[] | undefined,
   path: string,
+  budget: { retainedBytes: bigint },
 ): readonly RfcCallbackNamedValue[] {
   if (values === undefined) return Object.freeze([]);
   if (!Array.isArray(values)) throw new TypeError(`${path} must be an array`);
   const names = new Set<string>();
-  return Object.freeze(values.map((entry, index) => {
+  return Object.freeze(Array.from(values, (entry, index) => {
     if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
       throw new TypeError(`${path}[${index}] must be an object`);
     }
@@ -398,20 +424,25 @@ function snapshotNamedValues(
     names.add(name);
     return Object.freeze({
       name,
-      value: boundedCallbackSnapshot(entry.value, `${path}[${index}].value`),
+      value: boundedCallbackSnapshot(
+        entry.value,
+        `${path}[${index}].value`,
+        budget,
+      ),
     });
   }));
 }
 
 function snapshotTables(
   tables: readonly RfcCallbackTable[] | undefined,
+  budget: { retainedBytes: bigint },
 ): readonly RfcCallbackTable[] {
   if (tables === undefined) return Object.freeze([]);
   if (!Array.isArray(tables)) {
     throw new TypeError("callback response tables must be an array");
   }
   const names = new Set<string>();
-  return Object.freeze(tables.map((table, tableIndex) => {
+  return Object.freeze(Array.from(tables, (table, tableIndex) => {
     if (typeof table !== "object" || table === null || Array.isArray(table)) {
       throw new TypeError(`callback response tables[${tableIndex}] must be an object`);
     }
@@ -430,7 +461,16 @@ function snapshotTables(
       throw new TypeError(`callback response table ${name} rows must be an array`);
     }
     callbackUint32(table.rows.length, `callback response table ${name} row count`);
-    const rows = table.rows.map((row: Uint8Array, rowIndex: number) => {
+    if (table.rows.length !== 0 && rowByteLength === 0) {
+      throw new RangeError(
+        `callback response table ${name} cannot contain zero-width rows`,
+      );
+    }
+    reserveCallbackResponseBytes(
+      budget,
+      BigInt(rowByteLength) * BigInt(table.rows.length),
+    );
+    const rows = Array.from(table.rows, (row: Uint8Array, rowIndex: number) => {
       const snapshot = boundedCallbackSnapshot(
         row,
         `callback response table ${name} row ${rowIndex}`,
@@ -479,8 +519,13 @@ export function encodeCpicRfcCallbackResponse(
     }
     return encodeCpicRfcCallbackException(exception.value);
   }
-  const exports = snapshotNamedValues(response.exports, "callback response exports");
-  const tables = snapshotTables(response.tables);
+  const budget = { retainedBytes: 0n };
+  const exports = snapshotNamedValues(
+    response.exports,
+    "callback response exports",
+    budget,
+  );
+  const tables = snapshotTables(response.tables, budget);
   const names = new Set(exports.map((entry) => entry.name));
   for (const table of tables) {
     if (names.has(table.name)) {

--- a/test/cpic.test.ts
+++ b/test/cpic.test.ts
@@ -1942,6 +1942,14 @@ test("encodes CUT table inputs as full-width simple-compression records", () => 
       }),
     /ROWS row 0 contains 3 bytes; expected 4/,
   );
+  assert.throws(
+    () =>
+      encodeCpicCutFunctionRequest({
+        functionName: "Z_TABLE_CALL",
+        tables: [{ name: "ROWS", rowByteLength: 0, rows: [Buffer.alloc(0)] }],
+      }),
+    /ROWS cannot contain zero-width rows/,
+  );
 });
 
 test("returns cloned application fields only through the explicit result decoder", () => {

--- a/test/rfc-callback.test.ts
+++ b/test/rfc-callback.test.ts
@@ -181,4 +181,36 @@ test("rejects malformed callback grammar and unsafe handler tables", () => {
   const handler = () => ({ exports: [] });
   const snapshotted = snapshotRfcCallbackHandlers({ Z_CALLBACK: handler });
   assert.equal(snapshotted?.get("Z_CALLBACK"), handler);
+
+  assert.throws(
+    () => encodeCpicRfcCallbackResponse({
+      tables: [{ name: "ITEMS", rowByteLength: 0, rows: [Buffer.alloc(0)] }],
+    }),
+    /zero-width rows/u,
+  );
+
+  let oversizedRowRead = false;
+  const oversizedRows = [Buffer.alloc(1)];
+  Object.defineProperty(oversizedRows, 0, {
+    get() {
+      oversizedRowRead = true;
+      return Buffer.alloc(1);
+    },
+  });
+  assert.throws(
+    () => encodeCpicRfcCallbackResponse({
+      tables: [{
+        name: "ITEMS",
+        rowByteLength: 0xffff_ffff,
+        rows: oversizedRows,
+      }],
+    }),
+    /response value bytes exceed/u,
+  );
+  assert.equal(oversizedRowRead, false);
+
+  assert.throws(
+    () => encodeCpicRfcCallbackResponse({ exports: Array(1) }),
+    /must be an object/u,
+  );
 });


### PR DESCRIPTION
## Goal
Keep callback response materialization within the established CPIC memory bound.

## Content
- preflight aggregate export and table value bytes before encoding
- reject non-empty zero-width tables in callback and ordinary CUT requests
- reject sparse response arrays deterministically
- prove oversized tables fail before row values are read