### PR TITLE
feat: ping modern pinned connections

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -56,6 +56,7 @@ contributors:
 - `src/protocol/logon-ticket.ts`
 - `src/protocol/cpic.ts`
 - `src/protocol/rfc-callback.ts`
+- `src/compat/node-rfc-library.ts`
 - `src/metadata/rfc-structure-definition.ts`
 - `src/values/classic-xrfc.ts`
 - `src/values/recursive-xrfc.ts`
@@ -76,6 +77,7 @@ specifically these upstream files:
 - `internal/metadata/structure_definition.go`
 - `internal/client/session.go`
 - `rfc/callback.go`
+- `rfc/session.go`
 - `internal/xrfc/classic_xrfc.go`
 - `internal/xrfc/recursive_xrfc_codec.go`
 

--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -112,8 +112,8 @@
     },
     {
       "path": "dist/src/compat/node-rfc-library.d.ts",
-      "bytes": 2649,
-      "sha256": "806dc59eb024cf57292eb2243a99ef3f5aea30c940fb506eeb769250cd76e3d5"
+      "bytes": 2745,
+      "sha256": "d6b457adda1785d6eb67375b2d1674459aefe6183b6da595f9e06be50f52341f"
     },
     {
       "path": "dist/src/compat/node-rfc-pool.d.ts",
@@ -396,5 +396,5 @@
       "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "59d0b1664ee0c88914599977edaf6afe4a02fb05ec5a8d040aca8e0ccc2c3993"
+  "aggregateSha256": "038ef19bc5c07371d91e80a117bd645af7ed4e0cff8e7ea5dd35b3025d0e1866"
 }

--- a/docs_page/api.md
+++ b/docs_page/api.md
@@ -232,6 +232,7 @@ connection.execute(
   enableValidation = true,
   excludeParamsFromOutput = [],
 ): Promise<RfcObject>
+connection.ping(): Promise<boolean>
 connection.getMetadata(functionName): Promise<ModernRfcMetadata>
 connection.commit(): Promise<void>
 connection.rollback(): Promise<void>
@@ -255,6 +256,10 @@ for `Client` above.
 buckets. A parameter may appear in only one bucket. Validation is enabled by
 default. `excludeParamsFromOutput` marks those parameters not requested at SAP
 and omits them from the returned object.
+
+`ping()` sends `RFC_PING` over the same pinned conversation. Use it only while
+the connection is idle; it rejects while an `execute()` is active, because one
+RFC conversation carries only one call at a time.
 
 ### Transaction state rules
 

--- a/src/compat/node-rfc-library.ts
+++ b/src/compat/node-rfc-library.ts
@@ -630,6 +630,26 @@ export class RFCConnection {
       : new Error("RFC connection is closed");
   }
 
+  /** Keep the idle pinned conversation alive with RFC_PING. */
+  async ping(): Promise<boolean> {
+    this.#requireOpen("ping");
+    const admission = this.#claimExecute();
+    try {
+      const ready = this.#readyCycle("ping");
+      const cycle = ready ?? await this.#ensureCycle("ping");
+      await this.#executeCycle(
+        cycle,
+        "RFC_PING",
+        Object.freeze({}),
+        Object.freeze([]),
+      );
+      return true;
+    } finally {
+      if (this.#activeExecute === admission) this.#activeExecute = undefined;
+      this.#finishSessionOperation(admission);
+    }
+  }
+
   async execute(
     functionName: string,
     input: RFCInputParams = {},

--- a/test/modern-transaction-contract.test.ts
+++ b/test/modern-transaction-contract.test.ts
@@ -712,6 +712,23 @@ test("execute and commit share one lease, metadata stays on the repository lane,
   assert.equal(owner.events.at(-1), "retire");
 });
 
+test("ping keeps the idle pinned conversation alive and follows LUW rollover", async () => {
+  const { owner, connection } = await openFixture();
+
+  assert.equal(await connection.ping(), true);
+  assert.equal(owner.events.includes("invoke:1:RFC_PING"), true);
+
+  await connection.commit();
+  assert.equal(await connection.ping(), true);
+  assert.deepEqual(
+    owner.events.filter((event) => event.startsWith("acquire:")),
+    ["acquire:1", "acquire:2"],
+  );
+  assert.equal(owner.events.includes("invoke:2:RFC_PING"), true);
+
+  await connection.close();
+});
+
 test("execute preserves grouped inputs, Promise results, and excluded output fields", async () => {
   let capturedInput: Readonly<Record<string, unknown>> | undefined;
   const { owner, connection } = await openFixture({
@@ -1590,6 +1607,10 @@ test("close racing a business call aborts once, waits for its tail, and never se
       );
       return true;
     },
+  );
+  await assert.rejects(
+    connection.ping(),
+    /concurrent|active|calling|operation/iu,
   );
 
   let closeSettled = false;


### PR DESCRIPTION
## Goal
Let modern RFCConnection users keep an idle pinned conversation alive.

## Content
- add RFCConnection.ping() over the current RFC_PING transaction lane
- preserve single-call admission and lazy post-commit LUW rollover
- document the idle-only contract and refresh the API snapshot
- extend the existing Apache-2.0 open-rfc-go notice to rfc/session.go

## Verification
- full code suite
- lint and API-surface suite
- strict documentation build