### PR TITLE
feat: name callback xRFC inputs

### DIFF
--- a/conformance/api/public-types.v1.json
+++ b/conformance/api/public-types.v1.json
@@ -287,8 +287,8 @@
     },
     {
       "path": "dist/src/protocol/rfc-callback.d.ts",
-      "bytes": 2964,
-      "sha256": "f94bc09b88864b93604ef6d3569f2d7a2f719953a5192056224686339cd260de"
+      "bytes": 3064,
+      "sha256": "022dc666d23f69872ca3ec982bc5cc83eee31cfd7b402ea6d6abb26d1d3f37c0"
     },
     {
       "path": "dist/src/protocol/rfc-error-envelope.d.ts",
@@ -396,5 +396,5 @@
       "sha256": "3f7281a9719647b7faeb0c15cd021310eb4ddec4269c379380813dd129db7859"
     }
   ],
-  "aggregateSha256": "f64beabf9f12289b5fd22d7624fa45f570f1261d52ecc380b3fbec92e3b7062c"
+  "aggregateSha256": "ac65bc5c885896a271fd1258278350d722054e65210a4d2b6247fade0e602444"
 }

--- a/docs_page/api.md
+++ b/docs_page/api.md
@@ -87,9 +87,10 @@ graph, omit the option and keep the fail-closed result.
 Callback handlers execute while the outer call owns its physical session. Do
 not call the same client or await work from a handler. Interpret and construct
 raw parameter bytes using the callback RFM's exact ABAP metadata; this preview
-does not project callback values into normal JavaScript RFC objects. At most 64
-callbacks are serviced during one outer call. Callback request and response
-bytes must not be logged.
+does not project callback values into normal JavaScript RFC objects. Each xRFC
+input includes its canonical `name`, raw XML `value`, and source `chunkCount`.
+At most 64 callbacks are serviced during one outer call. Callback request and
+response bytes must not be logged.
 
 ```ts
 const client = new Client(connectionParameters, {

--- a/src/protocol/rfc-callback.ts
+++ b/src/protocol/rfc-callback.ts
@@ -17,6 +17,7 @@ import {
 import { MAX_APPC_APPLICATION_DATA_FRAGMENT_LENGTH } from "./appc.js";
 import { assertUnicodeScalarText } from "../values/unicode-scalar.js";
 import { decodeSimpleCompressedRfcTableRow } from "./classic-rfc.js";
+import { decodeRecursiveXrfcParameterName } from "../values/recursive-xrfc.js";
 
 // Adapted and hardened for TypeScript from open-rfc-go's Apache-2.0
 // internal/rfcserver request/response codec and rfc/callback framing at commit
@@ -36,6 +37,8 @@ export interface RfcCallbackTable {
 }
 
 export interface RfcCallbackXrfcParameter {
+  /** Canonical ABAP parameter name decoded from the xRFC XML root. */
+  readonly name: string;
   readonly value: Buffer;
   readonly chunkCount: number;
 }
@@ -369,8 +372,15 @@ export function decodeCpicRfcCallbackRequest(
           ) {
             throw new Error("callback xRFC parameter lacks its closing boundary");
           }
+          const value = Buffer.concat(chunks, byteLength);
+          const name = decodeRecursiveXrfcParameterName(value);
+          if (names.has(name)) {
+            throw new Error(`callback CUT request repeats input parameter ${name}`);
+          }
+          names.add(name);
           xrfcParameters.push(Object.freeze({
-            value: Buffer.concat(chunks, byteLength),
+            name,
+            value,
             chunkCount: chunks.length,
           }));
           break;

--- a/test/rfc-callback.test.ts
+++ b/test/rfc-callback.test.ts
@@ -51,9 +51,30 @@ test("decodes a bounded CUT callback request with raw values", () => {
     rows: [Buffer.from("01020304", "hex")],
   }]);
   assert.deepEqual(decoded.xrfcParameters, [{
+    name: "DEEP",
     value: Buffer.from("<DEEP><TEXT>one</TEXT></DEEP>"),
     chunkCount: 1,
   }]);
+});
+
+test("rejects malformed and colliding callback xRFC parameter roots", () => {
+  const request = (xml: string, importName?: string): Buffer =>
+    encodeCpicCutFunctionRequest({
+      functionName: "Z_CALLBACK",
+      imports: importName === undefined
+        ? []
+        : [{ name: importName, value: Buffer.alloc(2) }],
+      xrfcParameters: [{ name: "DIAGNOSTIC", value: Buffer.from(xml) }],
+    }).subarray(0, -8);
+
+  assert.throws(
+    () => decodeCpicRfcCallbackRequest(request("not XML")),
+    /top-level tag/u,
+  );
+  assert.throws(
+    () => decodeCpicRfcCallbackRequest(request("<DEEP></DEEP>", "DEEP")),
+    /repeats input parameter DEEP/u,
+  );
 });
 
 test("expands bounded simple-compressed callback table rows", () => {


### PR DESCRIPTION
## Goal
Preserve the canonical parameter identity of callback xRFC inputs.

## Content
- decode the ABAP parameter name from the canonical xRFC XML root
- expose name beside raw XML bytes and source chunk count
- reject malformed roots and names colliding with another callback input
- document the raw xRFC callback shape and refresh declarations

## Verification
- focused callback protocol and peer tests
- full code suite, lint, API surface, and strict docs build